### PR TITLE
feature/frontend > アップロードしたcsvのプレビュー機能を実装

### DIFF
--- a/frontend/src/components/csv-upload-page/CsvPreview.tsx
+++ b/frontend/src/components/csv-upload-page/CsvPreview.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  Paper, 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableContainer, 
+  TableHead, 
+  TableRow,
+  Typography,
+  Box,
+  Collapse
+} from '@mui/material';
+
+interface CsvPreviewProps {
+  file: File | null;
+  maxRows?: number;
+}
+
+export const CsvPreview: React.FC<CsvPreviewProps> = ({ file, maxRows = 5 }) => {
+  const [previewData, setPreviewData] = useState<string[][]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(true);
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewData([]);
+      setError(null);
+      return;
+    }
+
+    const reader = new FileReader();
+    
+    reader.onload = (e) => {
+      try {
+        const text = e.target?.result as string;
+        const lines = text.split('\n');
+        const data = lines
+          .filter(line => line.trim() !== '')
+          .slice(0, maxRows)
+          .map(line => line.split(','));
+        
+        setPreviewData(data);
+        setError(null);
+      } catch (err) {
+        setError('CSVファイルの解析中にエラーが発生しました');
+        setPreviewData([]);
+      }
+    };
+
+    reader.onerror = () => {
+      setError('ファイルの読み込み中にエラーが発生しました');
+      setPreviewData([]);
+    };
+
+    reader.readAsText(file);
+  }, [file, maxRows]);
+
+  if (!file) return null;
+
+  return (
+    <Paper 
+      elevation={2} 
+      sx={{ 
+        mt: 3, 
+        mb: 3, 
+        p: 2,
+        cursor: 'pointer'
+      }}
+      onClick={() => setExpanded(!expanded)}
+    >
+      <Typography variant="h6" gutterBottom>
+        CSVプレビュー {expanded ? '▼' : '▶'} 
+        <Typography variant="caption" sx={{ ml: 1 }}>
+          (最初の{maxRows}行のみ表示 - クリックで{expanded ? '折りたたむ' : '展開'})
+        </Typography>
+      </Typography>
+
+      <Collapse in={expanded}>
+        {error ? (
+          <Typography color="error">{error}</Typography>
+        ) : previewData.length > 0 ? (
+          <TableContainer component={Box} sx={{ maxHeight: 300 }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  {previewData[0].map((cell, index) => (
+                    <TableCell key={index} sx={{ fontWeight: 'bold' }}>
+                      {cell}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {previewData.slice(1).map((row, rowIndex) => (
+                  <TableRow key={rowIndex}>
+                    {row.map((cell, cellIndex) => (
+                      <TableCell key={cellIndex}>{cell}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : (
+          <Typography>プレビューするデータがありません</Typography>
+        )}
+      </Collapse>
+    </Paper>
+  );
+};

--- a/frontend/src/components/csv-upload-page/index.ts
+++ b/frontend/src/components/csv-upload-page/index.ts
@@ -4,3 +4,4 @@ export { FileUploader } from './FileUploader';
 export { ResultsTable } from './ResultsTable';
 export { Footer } from './Footer';
 export { CardTypeSelector } from './CardTypeSelector';
+export { CsvPreview } from './CsvPreview';

--- a/frontend/src/components/csv-upload-page/index.tsx
+++ b/frontend/src/components/csv-upload-page/index.tsx
@@ -1,7 +1,0 @@
-import { Header } from './Header';
-import { Instructions } from './Instructions';
-import { FileUploader } from './FileUploader';
-import { ResultsTable } from './ResultsTable';
-import { Footer } from './Footer';
-
-export { Header, Instructions, FileUploader, ResultsTable, Footer };

--- a/frontend/src/pages/CsvUploadPage.tsx
+++ b/frontend/src/pages/CsvUploadPage.tsx
@@ -2,13 +2,13 @@ import { useState, useCallback } from 'react';
 import { Container } from '@mui/material';
 import useStore from '../store';
 import { processCSVData, CardType } from '../components/csv-upload-page/utils/csvProcessor/index';
-import { CardStatementSummary } from '../types/models/cardStatement';
 import { 
   Header, 
   Instructions, 
   FileUploader, 
   ResultsTable, 
-  Footer 
+  Footer,
+  CsvPreview
 } from '../components/csv-upload-page';
 
 export const CsvUploadPage = () => {
@@ -57,6 +57,9 @@ export const CsvUploadPage = () => {
         cardType={cardType}
         setCardType={setCardType}
       />
+      
+      {/* CSVプレビューコンポーネントを追加 */}
+      <CsvPreview file={csvFile} maxRows={10} />
       
       <ResultsTable 
         cardStatementSummaries={cardStatementSummaries}


### PR DESCRIPTION
## 概要
### CSV プレビュー機能の追加
CSVファイルをアップロードした後、処理する前にファイルの内容をプレビューできる機能を追加。
ユーザーは正しいファイルをアップロードしたかどうかを確認できるようになる。

## 変更内容
- `CsvPreview` コンポーネントを新規作成
- アップロードしたCSVファイルの最初の数行を表示する機能
- プレビュー表示の折りたたみ機能
- エラーハンドリングの追加

## 技術的詳細
- React Hooksを使用してファイル内容の読み込みと状態管理を実装
- Material UIのTableコンポーネントを使用してCSVデータを表形式で表示
- Collapseコンポーネントを使用して表示/非表示を切り替え可能に
- FileReaderAPIを使用してCSVファイルの内容を非同期で読み込み

## テスト方法
1. CSVアップロードページに移動
2. CSVファイルをアップロード
3. ファイルがアップロードされると自動的にプレビューが表示される
4. プレビューヘッダーをクリックして折りたたみ/展開できることを確認

## 関連Issue
 - close #11 