### PR TITLE
feature/backend&frontend > 集計用データの保存フラグを変更

### DIFF
--- a/backend/controller/card_statement_controller.go
+++ b/backend/controller/card_statement_controller.go
@@ -13,6 +13,8 @@ type ICardStatementController interface {
 	GetAllCardStatements(c echo.Context) error
 	GetCardStatementById(c echo.Context) error
 	UploadCSV(c echo.Context) error
+	PreviewCSV(c echo.Context) error
+	SaveCardStatements(c echo.Context) error
 }
 
 type cardStatementController struct {
@@ -112,6 +114,83 @@ func (csc *cardStatementController) UploadCSV(c echo.Context) error {
 	
 	// CSVの処理
 	cardStatementsRes, err := csc.csu.ProcessCSV(file, request)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	
+	return c.JSON(http.StatusCreated, cardStatementsRes)
+}
+
+// PreviewCSV CSVファイルをアップロードしてプレビュー（保存なし）
+// @Summary CSVファイルをアップロードしてプレビュー
+// @Description カード明細のCSVファイルをアップロードして解析するが、DBには保存しない
+// @Tags card-statements
+// @Accept multipart/form-data
+// @Produce json
+// @Param file formData file true "CSVファイル"
+// @Param card_type formData string true "カード種類 (rakuten, mufg, epos)"
+// @Success 200 {array} model.CardStatementResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /card-statements/preview [post]
+func (csc *cardStatementController) PreviewCSV(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	// ファイルの取得
+	file, err := c.FormFile("file")
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ファイルが見つかりません"})
+	}
+	
+	// カード種類の取得
+	cardType := c.FormValue("card_type")
+	if cardType == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "card_type is required"})
+	}
+	
+	request := model.CardStatementPreviewRequest{
+		CardType: cardType,
+		UserId:   userId,
+	}
+	
+	// CSVのプレビュー処理
+	cardStatementsRes, err := csc.csu.PreviewCSV(file, request)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	
+	return c.JSON(http.StatusOK, cardStatementsRes)
+}
+
+// SaveCardStatements プレビューしたカード明細をDBに保存
+// @Summary プレビューしたカード明細を保存
+// @Description プレビューしたカード明細データをデータベースに保存する
+// @Tags card-statements
+// @Accept json
+// @Produce json
+// @Param request body model.CardStatementSaveRequest true "保存するカード明細データ"
+// @Success 201 {array} model.CardStatementResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /card-statements/save [post]
+func (csc *cardStatementController) SaveCardStatements(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	var request model.CardStatementSaveRequest
+	if err := c.Bind(&request); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+	
+	request.UserId = userId
+	
+	// カード明細の保存
+	cardStatementsRes, err := csc.csu.SaveCardStatements(request)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}

--- a/backend/controller/dev_card_statement_controller.go
+++ b/backend/controller/dev_card_statement_controller.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"monelog/model"
+	"monelog/usecase"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type IDevCardStatementController interface {
+	DeleteAllCardStatements(c echo.Context) error
+}
+
+type devCardStatementController struct {
+	dcsu usecase.IDevCardStatementUsecase
+}
+
+func NewDevCardStatementController(dcsu usecase.IDevCardStatementUsecase) IDevCardStatementController {
+	return &devCardStatementController{dcsu}
+}
+
+// DeleteAllCardStatements 開発環境限定で全カード明細を削除
+// @Summary 開発環境限定で全カード明細を削除
+// @Description 開発環境限定で全カード明細レコードを削除する
+// @Tags dev
+// @Accept json
+// @Produce json
+// @Success 200 {object} model.DevCardStatementResponse
+// @Failure 403 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /dev/card-statements/delete-all [post]
+func (dcsc *devCardStatementController) DeleteAllCardStatements(c echo.Context) error {
+	// 空のリクエストを作成
+	request := model.DevCardStatementRequest{}
+
+	response, err := dcsc.dcsu.DeleteAllCardStatements(request)
+	if err != nil {
+		// エラーの種類に応じてステータスコードを変える
+		if err.Error() == "this operation is only allowed in development environment" {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, response)
+}

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -50,6 +50,121 @@ const docTemplate = `{
                 }
             }
         },
+        "/card-statements/preview": {
+            "post": {
+                "description": "カード明細のCSVファイルをアップロードして解析するが、DBには保存しない",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "card-statements"
+                ],
+                "summary": "CSVファイルをアップロードしてプレビュー",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "CSVファイル",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "カード種類 (rakuten, mufg, epos)",
+                        "name": "card_type",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CardStatementResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/card-statements/save": {
+            "post": {
+                "description": "プレビューしたカード明細データをデータベースに保存する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "card-statements"
+                ],
+                "summary": "プレビューしたカード明細を保存",
+                "parameters": [
+                    {
+                        "description": "保存するカード明細データ",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CardStatementSaveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CardStatementResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/card-statements/upload": {
             "post": {
                 "description": "カード明細のCSVファイルをアップロードして解析する",
@@ -178,6 +293,47 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.CsrfTokenResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/dev/card-statements/delete-all": {
+            "post": {
+                "description": "開発環境限定で全カード明細レコードを削除する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "dev"
+                ],
+                "summary": "開発環境限定で全カード明細を削除",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.DevCardStatementResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -626,12 +782,94 @@ const docTemplate = `{
                 }
             }
         },
+        "model.CardStatementSaveRequest": {
+            "type": "object",
+            "required": [
+                "card_statements",
+                "card_type"
+            ],
+            "properties": {
+                "card_statements": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.CardStatementSummary"
+                    }
+                },
+                "card_type": {
+                    "type": "string",
+                    "example": "rakuten"
+                }
+            }
+        },
+        "model.CardStatementSummary": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "annual_rate": {
+                    "type": "number"
+                },
+                "card_type": {
+                    "type": "string"
+                },
+                "charge_amount": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "installment_count": {
+                    "type": "integer"
+                },
+                "monthly_rate": {
+                    "type": "number"
+                },
+                "payment_count": {
+                    "type": "integer"
+                },
+                "payment_date": {
+                    "type": "string"
+                },
+                "payment_month": {
+                    "type": "string"
+                },
+                "remaining_balance": {
+                    "type": "integer"
+                },
+                "statement_no": {
+                    "type": "integer"
+                },
+                "total_charge_amount": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "use_date": {
+                    "type": "string"
+                }
+            }
+        },
         "model.CsrfTokenResponse": {
             "type": "object",
             "properties": {
                 "csrf_token": {
                     "type": "string",
                     "example": "token-string-here"
+                }
+            }
+        },
+        "model.DevCardStatementResponse": {
+            "type": "object",
+            "properties": {
+                "deleted_rows": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "message": {
+                    "type": "string",
+                    "example": "All card statements deleted successfully"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -47,6 +47,121 @@
                 }
             }
         },
+        "/card-statements/preview": {
+            "post": {
+                "description": "カード明細のCSVファイルをアップロードして解析するが、DBには保存しない",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "card-statements"
+                ],
+                "summary": "CSVファイルをアップロードしてプレビュー",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "CSVファイル",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "カード種類 (rakuten, mufg, epos)",
+                        "name": "card_type",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CardStatementResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/card-statements/save": {
+            "post": {
+                "description": "プレビューしたカード明細データをデータベースに保存する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "card-statements"
+                ],
+                "summary": "プレビューしたカード明細を保存",
+                "parameters": [
+                    {
+                        "description": "保存するカード明細データ",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CardStatementSaveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CardStatementResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/card-statements/upload": {
             "post": {
                 "description": "カード明細のCSVファイルをアップロードして解析する",
@@ -175,6 +290,47 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.CsrfTokenResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/dev/card-statements/delete-all": {
+            "post": {
+                "description": "開発環境限定で全カード明細レコードを削除する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "dev"
+                ],
+                "summary": "開発環境限定で全カード明細を削除",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.DevCardStatementResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -623,12 +779,94 @@
                 }
             }
         },
+        "model.CardStatementSaveRequest": {
+            "type": "object",
+            "required": [
+                "card_statements",
+                "card_type"
+            ],
+            "properties": {
+                "card_statements": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.CardStatementSummary"
+                    }
+                },
+                "card_type": {
+                    "type": "string",
+                    "example": "rakuten"
+                }
+            }
+        },
+        "model.CardStatementSummary": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "annual_rate": {
+                    "type": "number"
+                },
+                "card_type": {
+                    "type": "string"
+                },
+                "charge_amount": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "installment_count": {
+                    "type": "integer"
+                },
+                "monthly_rate": {
+                    "type": "number"
+                },
+                "payment_count": {
+                    "type": "integer"
+                },
+                "payment_date": {
+                    "type": "string"
+                },
+                "payment_month": {
+                    "type": "string"
+                },
+                "remaining_balance": {
+                    "type": "integer"
+                },
+                "statement_no": {
+                    "type": "integer"
+                },
+                "total_charge_amount": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "use_date": {
+                    "type": "string"
+                }
+            }
+        },
         "model.CsrfTokenResponse": {
             "type": "object",
             "properties": {
                 "csrf_token": {
                     "type": "string",
                     "example": "token-string-here"
+                }
+            }
+        },
+        "model.DevCardStatementResponse": {
+            "type": "object",
+            "properties": {
+                "deleted_rows": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "message": {
+                    "type": "string",
+                    "example": "All card statements deleted successfully"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -57,10 +57,65 @@ definitions:
         example: 2023/01/01
         type: string
     type: object
+  model.CardStatementSaveRequest:
+    properties:
+      card_statements:
+        items:
+          $ref: '#/definitions/model.CardStatementSummary'
+        type: array
+      card_type:
+        example: rakuten
+        type: string
+    required:
+    - card_statements
+    - card_type
+    type: object
+  model.CardStatementSummary:
+    properties:
+      amount:
+        type: integer
+      annual_rate:
+        type: number
+      card_type:
+        type: string
+      charge_amount:
+        type: integer
+      description:
+        type: string
+      installment_count:
+        type: integer
+      monthly_rate:
+        type: number
+      payment_count:
+        type: integer
+      payment_date:
+        type: string
+      payment_month:
+        type: string
+      remaining_balance:
+        type: integer
+      statement_no:
+        type: integer
+      total_charge_amount:
+        type: integer
+      type:
+        type: string
+      use_date:
+        type: string
+    type: object
   model.CsrfTokenResponse:
     properties:
       csrf_token:
         example: token-string-here
+        type: string
+    type: object
+  model.DevCardStatementResponse:
+    properties:
+      deleted_rows:
+        example: 42
+        type: integer
+      message:
+        example: All card statements deleted successfully
         type: string
     type: object
   model.TaskRequest:
@@ -183,6 +238,82 @@ paths:
       summary: 特定のカード明細を取得
       tags:
       - card-statements
+  /card-statements/preview:
+    post:
+      consumes:
+      - multipart/form-data
+      description: カード明細のCSVファイルをアップロードして解析するが、DBには保存しない
+      parameters:
+      - description: CSVファイル
+        in: formData
+        name: file
+        required: true
+        type: file
+      - description: カード種類 (rakuten, mufg, epos)
+        in: formData
+        name: card_type
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.CardStatementResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: CSVファイルをアップロードしてプレビュー
+      tags:
+      - card-statements
+  /card-statements/save:
+    post:
+      consumes:
+      - application/json
+      description: プレビューしたカード明細データをデータベースに保存する
+      parameters:
+      - description: 保存するカード明細データ
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.CardStatementSaveRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            items:
+              $ref: '#/definitions/model.CardStatementResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: プレビューしたカード明細を保存
+      tags:
+      - card-statements
   /card-statements/upload:
     post:
       consumes:
@@ -238,6 +369,33 @@ paths:
       summary: CSRFトークン取得
       tags:
       - users
+  /dev/card-statements/delete-all:
+    post:
+      consumes:
+      - application/json
+      description: 開発環境限定で全カード明細レコードを削除する
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.DevCardStatementResponse'
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: 開発環境限定で全カード明細を削除
+      tags:
+      - dev
   /login:
     post:
       consumes:

--- a/backend/main_entry_module/main_entry_package.go
+++ b/backend/main_entry_module/main_entry_package.go
@@ -13,6 +13,7 @@ type MainEntryPackage struct {
 	UserController            controller.IUserController
 	TaskController            controller.ITaskController 
 	CardStatementController   controller.ICardStatementController
+	DevCardStatementController controller.IDevCardStatementController
 	
 	// Swaggerハンドラーを追加（オプション）
 	SwaggerEnabled            bool
@@ -28,6 +29,7 @@ func NewMainEntryPackage(db *gorm.DB) *MainEntryPackage {
 	entry.initUserModule(db)
 	entry.initTaskModule(db)
 	entry.initCardStatementModule(db)
+	entry.initDevCardStatementModule(db)
 
 	return entry
 }
@@ -38,4 +40,12 @@ func (e *MainEntryPackage) initCardStatementModule(db *gorm.DB) {
 	cardStatementValidator := validator.NewCardStatementValidator()
 	cardStatementUsecase := usecase.NewCardStatementUsecase(cardStatementRepo, cardStatementValidator)
 	e.CardStatementController = controller.NewCardStatementController(cardStatementUsecase)
+}
+
+// initDevCardStatementModule は開発環境限定のカード明細関連のモジュールを初期化する
+func (e *MainEntryPackage) initDevCardStatementModule(db *gorm.DB) {
+	devCardStatementRepo := repository.NewDevCardStatementRepository(db)
+	devCardStatementValidator := validator.NewDevCardStatementValidator()
+	devCardStatementUsecase := usecase.NewDevCardStatementUsecase(devCardStatementRepo, devCardStatementValidator)
+	e.DevCardStatementController = controller.NewDevCardStatementController(devCardStatementUsecase)
 }

--- a/backend/main_entry_module/router_module.go
+++ b/backend/main_entry_module/router_module.go
@@ -14,6 +14,7 @@ func (m *MainEntryPackage) InitRouter() *echo.Echo {
 		m.UserController,
 		m.TaskController,
 		m.CardStatementController,
+		m.DevCardStatementController, // 追加
 	)
 	
 	// Swaggerのエンドポイントを追加

--- a/backend/model/card_statement.go
+++ b/backend/model/card_statement.go
@@ -121,3 +121,16 @@ func (css *CardStatementSummary) ToModel(userId uint) CardStatement {
 		UserId:            userId,
 	}
 }
+
+// CardStatementPreviewRequest CSVプレビュー用リクエスト
+type CardStatementPreviewRequest struct {
+	CardType string `json:"card_type" validate:"required" example:"rakuten"`
+	UserId   uint   `json:"-"`
+}
+
+// CardStatementSaveRequest 一時データを保存するリクエスト
+type CardStatementSaveRequest struct {
+	CardStatements []CardStatementSummary `json:"card_statements" validate:"required"`
+	CardType       string                 `json:"card_type" validate:"required" example:"rakuten"`
+	UserId         uint                   `json:"-"`
+}

--- a/backend/model/dev_card_statement.go
+++ b/backend/model/dev_card_statement.go
@@ -1,0 +1,13 @@
+package model
+
+// DevCardStatementRequest 開発環境限定のカード明細削除リクエスト
+// dev_tokenを削除
+type DevCardStatementRequest struct {
+    // フィールドを空にする（または必要に応じて他のフィールドを追加）
+}
+
+// DevCardStatementResponse 開発環境限定のカード明細削除レスポンス
+type DevCardStatementResponse struct {
+	Message     string `json:"message" example:"All card statements deleted successfully"`
+	DeletedRows int64  `json:"deleted_rows" example:"42"`
+}

--- a/backend/repository/dev_card_statement_repository.go
+++ b/backend/repository/dev_card_statement_repository.go
@@ -1,0 +1,26 @@
+package repository
+
+import (
+	"monelog/model"
+	"gorm.io/gorm"
+)
+
+type IDevCardStatementRepository interface {
+	DeleteAllCardStatements() (int64, error)
+}
+
+type devCardStatementRepository struct {
+	db *gorm.DB
+}
+
+func NewDevCardStatementRepository(db *gorm.DB) IDevCardStatementRepository {
+	return &devCardStatementRepository{db}
+}
+
+func (dcsr *devCardStatementRepository) DeleteAllCardStatements() (int64, error) {
+	result := dcsr.db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&model.CardStatement{})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
+}

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -9,7 +9,8 @@ import (
 func NewRouter(
 	uc controller.IUserController,
 	tc controller.ITaskController,
-	csc controller.ICardStatementController) *echo.Echo {
+	csc controller.ICardStatementController,
+	dcsc controller.IDevCardStatementController) *echo.Echo {
 	
 	e := echo.New()
 	
@@ -19,7 +20,8 @@ func NewRouter(
 	// 各種ルートの設定
 	routes.SetupAuthRoutes(e, uc)
 	routes.SetupTaskRoutes(e, tc)
-	routes.SetupCardStatementRoutes(e, csc)
+	routes.SetupCardStatementRoutes(e, csc) // カード明細ルートの設定
+	routes.SetupDevRoutes(e, dcsc)
 	
 	return e
 }

--- a/backend/router/routes/card_statements.go
+++ b/backend/router/routes/card_statements.go
@@ -10,7 +10,19 @@ import (
 func SetupCardStatementRoutes(e *echo.Echo, csc controller.ICardStatementController) {
 	cs := e.Group("/card-statements")
 	cs.Use(middleware.GetJWTMiddleware())
+	
+	// 一覧取得
 	cs.GET("", csc.GetAllCardStatements)
+	
+	// 個別取得
 	cs.GET("/:cardStatementId", csc.GetCardStatementById)
+	
+	// CSVアップロード（直接保存）- 既存機能
 	cs.POST("/upload", csc.UploadCSV)
+	
+	// CSVプレビュー（保存なし）- 新機能
+	cs.POST("/preview", csc.PreviewCSV)
+	
+	// プレビューデータ保存 - 新機能
+	cs.POST("/save", csc.SaveCardStatements)
 }

--- a/backend/router/routes/dev.go
+++ b/backend/router/routes/dev.go
@@ -1,0 +1,24 @@
+package routes
+
+import (
+	"monelog/controller"
+	"os"
+
+	"github.com/labstack/echo/v4"
+)
+
+// SetupDevRoutes は開発環境限定のルートを設定します
+func SetupDevRoutes(e *echo.Echo, dcsc controller.IDevCardStatementController) {
+	// 開発環境かどうかチェック
+	env := os.Getenv("APP_ENV")
+	if env != "development" && env != "dev" && env != "" {
+		return // 開発環境でなければルートを設定しない
+	}
+
+	// 開発用ルートグループ
+	dev := e.Group("/dev")
+	
+	// カード明細関連
+	devCardStatements := dev.Group("/card-statements")
+	devCardStatements.POST("/delete-all", dcsc.DeleteAllCardStatements)
+}

--- a/backend/usecase/dev_card_statement_usecase.go
+++ b/backend/usecase/dev_card_statement_usecase.go
@@ -1,0 +1,50 @@
+package usecase
+
+import (
+	"errors"
+	"monelog/model"
+	"monelog/repository"
+	"monelog/validator"
+)
+
+type IDevCardStatementUsecase interface {
+	DeleteAllCardStatements(request model.DevCardStatementRequest) (model.DevCardStatementResponse, error)
+}
+
+type devCardStatementUsecase struct {
+	dcsr repository.IDevCardStatementRepository
+	dcsv validator.IDevCardStatementValidator
+}
+
+func NewDevCardStatementUsecase(
+	dcsr repository.IDevCardStatementRepository,
+	dcsv validator.IDevCardStatementValidator,
+) IDevCardStatementUsecase {
+	return &devCardStatementUsecase{dcsr, dcsv}
+}
+
+func (dcsu *devCardStatementUsecase) DeleteAllCardStatements(request model.DevCardStatementRequest) (model.DevCardStatementResponse, error) {
+	// 開発環境かどうかチェック
+	if !dcsu.dcsv.IsDevEnvironment() {
+		return model.DevCardStatementResponse{}, errors.New("this operation is only allowed in development environment")
+	}
+
+	// リクエストのバリデーション（空になりました）
+	if err := dcsu.dcsv.ValidateDevCardStatementRequest(request); err != nil {
+		return model.DevCardStatementResponse{}, err
+	}
+
+	// 全レコード削除
+	deletedRows, err := dcsu.dcsr.DeleteAllCardStatements()
+	if err != nil {
+		return model.DevCardStatementResponse{}, err
+	}
+
+	// レスポンス作成
+	response := model.DevCardStatementResponse{
+		Message:     "All card statements deleted successfully",
+		DeletedRows: deletedRows,
+	}
+
+	return response, nil
+}

--- a/backend/validator/card_statement_validator.go
+++ b/backend/validator/card_statement_validator.go
@@ -8,6 +8,8 @@ import (
 
 type ICardStatementValidator interface {
 	ValidateCardStatementRequest(request model.CardStatementRequest) error
+	ValidateCardStatementPreviewRequest(request model.CardStatementPreviewRequest) error
+	ValidateCardStatementSaveRequest(request model.CardStatementSaveRequest) error
 }
 
 type cardStatementValidator struct{}
@@ -22,6 +24,30 @@ func (csv *cardStatementValidator) ValidateCardStatementRequest(request model.Ca
 			&request.CardType,
 			validation.Required.Error("card_type is required"),
 			validation.In("rakuten", "mufg", "epos").Error("card_type must be one of: rakuten, mufg, epos"),
+		),
+	)
+}
+
+func (csv *cardStatementValidator) ValidateCardStatementPreviewRequest(request model.CardStatementPreviewRequest) error {
+	return validation.ValidateStruct(&request,
+		validation.Field(
+			&request.CardType,
+			validation.Required.Error("card_type is required"),
+			validation.In("rakuten", "mufg", "epos").Error("card_type must be one of: rakuten, mufg, epos"),
+		),
+	)
+}
+
+func (csv *cardStatementValidator) ValidateCardStatementSaveRequest(request model.CardStatementSaveRequest) error {
+	return validation.ValidateStruct(&request,
+		validation.Field(
+			&request.CardType,
+			validation.Required.Error("card_type is required"),
+			validation.In("rakuten", "mufg", "epos").Error("card_type must be one of: rakuten, mufg, epos"),
+		),
+		validation.Field(
+			&request.CardStatements,
+			validation.Required.Error("card_statements is required"),
 		),
 	)
 }

--- a/backend/validator/dev_card_statement_validator.go
+++ b/backend/validator/dev_card_statement_validator.go
@@ -1,0 +1,28 @@
+package validator
+
+import (
+	"monelog/model"
+	"os"
+)
+
+type IDevCardStatementValidator interface {
+	ValidateDevCardStatementRequest(request model.DevCardStatementRequest) error
+	IsDevEnvironment() bool
+}
+
+type devCardStatementValidator struct{}
+
+func NewDevCardStatementValidator() IDevCardStatementValidator {
+	return &devCardStatementValidator{}
+}
+
+func (dcsv *devCardStatementValidator) ValidateDevCardStatementRequest(request model.DevCardStatementRequest) error {
+	// dev_tokenのバリデーションを削除
+	// 必要に応じて他のバリデーションを追加
+	return nil
+}
+
+func (dcsv *devCardStatementValidator) IsDevEnvironment() bool {
+	env := os.Getenv("APP_ENV")
+	return env == "development" || env == "dev" || env == ""
+}

--- a/frontend/src/api/cardStatements.ts
+++ b/frontend/src/api/cardStatements.ts
@@ -33,6 +33,41 @@ export const uploadCSV = async (file: File, cardType: CardType): Promise<CardSta
   return mapResponseToSummaries(response.data);
 };
 
+// CSVファイルをプレビュー（保存なし）
+export const previewCSV = async (file: File, cardType: CardType): Promise<CardStatementSummary[]> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('card_type', cardType);
+    
+    const response = await axios.post(
+      `${process.env.REACT_APP_API_URL}/card-statements/preview`, 
+      formData, 
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    );
+    
+    return mapResponseToSummaries(response.data);
+  };
+  
+  // プレビューしたデータを保存
+  export const saveCardStatements = async (
+    cardStatements: CardStatementSummary[], 
+    cardType: CardType
+  ): Promise<CardStatementSummary[]> => {
+    const response = await axios.post(
+      `${process.env.REACT_APP_API_URL}/card-statements/save`,
+      {
+        card_statements: cardStatements,
+        card_type: cardType
+      }
+    );
+    
+    return mapResponseToSummaries(response.data);
+  };
+  
 // バックエンドのレスポンスをフロントエンドの型に変換するヘルパー関数
 function mapResponseToSummary(item: any): CardStatementSummary {
   return {

--- a/frontend/src/components/csv-upload-page/ResultsTable.tsx
+++ b/frontend/src/components/csv-upload-page/ResultsTable.tsx
@@ -14,11 +14,13 @@ import { CardStatementSummary } from '../../types/models/cardStatement';
 interface ResultsTableProps {
   cardStatementSummaries: CardStatementSummary[];
   clearResults: () => void;
+  isPreviewData?: boolean; // 追加: プレビューデータかどうかを示すフラグ
 }
 
 export const ResultsTable: React.FC<ResultsTableProps> = ({ 
   cardStatementSummaries, 
-  clearResults 
+  clearResults,
+  isPreviewData = false // デフォルト値を設定
 }) => {
   if (cardStatementSummaries.length === 0) {
     return null;
@@ -28,10 +30,11 @@ export const ResultsTable: React.FC<ResultsTableProps> = ({
     <Box sx={{ mt: 4, animation: 'fadeIn 0.5s ease-in-out' }}>
       <Paper elevation={2} sx={{ p: 3, mb: 2 }}>
         <Typography variant="h5" component="h2" gutterBottom>
-          集計結果
+          {isPreviewData ? 'プレビュー結果' : '集計結果'}
         </Typography>
         <Typography variant="body2" color="text.secondary">
-          {cardStatementSummaries.length}件のレコードが処理されました。
+          {cardStatementSummaries.length}件のレコードが{isPreviewData ? 'プレビュー' : '処理'}されました。
+          {isPreviewData && '「データを保存する」ボタンをクリックすると、データベースに保存されます。'}
           分割払いの支払いスケジュールは以下の通りです。
         </Typography>
       </Paper>

--- a/frontend/src/hooks/mutateHooks/useMutateCardStatements.ts
+++ b/frontend/src/hooks/mutateHooks/useMutateCardStatements.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { uploadCSV } from '../../api/cardStatements';
+import { uploadCSV, previewCSV, saveCardStatements } from '../../api/cardStatements';
 import { CardType } from '../../types/cardType';
+import { CardStatementSummary } from '../../types/models/cardStatement';
 
 export const useMutateCardStatements = () => {
   const queryClient = useQueryClient();
 
+  // 既存のミューテーション（後方互換性のために残す）
   const uploadCSVMutation = useMutation({
     mutationFn: ({ file, cardType }: { file: File, cardType: CardType }) => 
       uploadCSV(file, cardType),
@@ -17,5 +19,32 @@ export const useMutateCardStatements = () => {
     },
   });
 
-  return { uploadCSVMutation };
+  // 新しいプレビューミューテーション
+  const previewCSVMutation = useMutation({
+    mutationFn: ({ file, cardType }: { file: File, cardType: CardType }) => 
+      previewCSV(file, cardType),
+    onError: (err: any) => {
+      console.error('CSVプレビューエラー:', err);
+      throw err;
+    },
+  });
+
+  // 保存ミューテーション
+  const saveCardStatementsMutation = useMutation({
+    mutationFn: ({ cardStatements, cardType }: { cardStatements: CardStatementSummary[], cardType: CardType }) => 
+      saveCardStatements(cardStatements, cardType),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['cardStatements'], data);
+    },
+    onError: (err: any) => {
+      console.error('カード明細保存エラー:', err);
+      throw err;
+    },
+  });
+
+  return { 
+    uploadCSVMutation, 
+    previewCSVMutation,
+    saveCardStatementsMutation
+  };
 };


### PR DESCRIPTION
## 概要
### カード明細CSVアップロードのプレビュー機能実装PR
このPRでは、カード明細CSVをアップロードした際に、すぐにデータベースに保存するのではなく、
まずプレビュー表示し、ユーザーが確認した後に「保存」ボタンを押すことでデータベースに保存される仕組みに変更。

## 変更内容
1. フロントエンドでCSVアップロード時にプレビュー表示する機能を追加
2. バックエンドAPIでプレビュー用と保存用のエンドポイントを分離
3. ユーザーインターフェースに保存ボタンを追加

## 技術的な変更点
- フロントエンド側で新しいAPIエンドポイント（/card-statements/preview, /card-statements/save）を使用するよう変更
- バックエンドでは既存のCSV処理ロジックを再利用しつつ、DBへの保存を分離
- ユーザーインターフェースにプレビュー状態と保存ボタンを追加

## テスト方法
1. CSVファイルをアップロードする
2. プレビュー結果が表示されることを確認
3. 「データを保存する」ボタンをクリックして保存
4. 保存後のデータが正しく表示されることを確認

## 関連
close #17 