### PR TITLE
fix-feature/csvアップロード画面から生成される集計用レコードに関するapi連携の修正

### DIFF
--- a/frontend/src/api/cardStatements.ts
+++ b/frontend/src/api/cardStatements.ts
@@ -57,11 +57,38 @@ export const previewCSV = async (file: File, cardType: CardType): Promise<CardSt
     cardStatements: CardStatementSummary[], 
     cardType: CardType
   ): Promise<CardStatementSummary[]> => {
+    // 必要なフィールドが全て含まれていることを確認
+    const payload = {
+      card_statements: cardStatements.map(statement => ({
+        // フロントエンドの型（camelCase）からバックエンドの型（snake_case）へ変換
+        type: statement.type,
+        statement_no: statement.statementNo,
+        card_type: statement.cardType || cardType, // cardTypeを使用
+        description: statement.description,
+        use_date: statement.useDate,
+        payment_date: statement.paymentDate,
+        payment_month: statement.paymentMonth,
+        amount: statement.amount,
+        total_charge_amount: statement.totalChargeAmount,
+        charge_amount: statement.chargeAmount,
+        remaining_balance: statement.remainingBalance,
+        payment_count: statement.paymentCount,
+        installment_count: statement.installmentCount,
+        annual_rate: statement.annualRate,
+        monthly_rate: statement.monthlyRate
+      })),
+      card_type: cardType
+    };
+    
+    console.log('APIに送信するペイロード:', JSON.stringify(payload, null, 2));
+    
     const response = await axios.post(
       `${process.env.REACT_APP_API_URL}/card-statements/save`,
+      payload,
       {
-        card_statements: cardStatements,
-        card_type: cardType
+        headers: {
+          'Content-Type': 'application/json',
+        },
       }
     );
     

--- a/frontend/src/hooks/mutateHooks/useMutateCardStatements.ts
+++ b/frontend/src/hooks/mutateHooks/useMutateCardStatements.ts
@@ -31,9 +31,13 @@ export const useMutateCardStatements = () => {
 
   // 保存ミューテーション
   const saveCardStatementsMutation = useMutation({
-    mutationFn: ({ cardStatements, cardType }: { cardStatements: CardStatementSummary[], cardType: CardType }) => 
-      saveCardStatements(cardStatements, cardType),
+    mutationFn: ({ cardStatements, cardType }: { cardStatements: CardStatementSummary[], cardType: CardType }) => {
+      console.log('保存するデータ（変換前）:', JSON.stringify(cardStatements, null, 2));
+      console.log('カード種類:', cardType);
+      return saveCardStatements(cardStatements, cardType);
+    },
     onSuccess: (data) => {
+      console.log('保存成功:', JSON.stringify(data, null, 2));
       queryClient.setQueryData(['cardStatements'], data);
     },
     onError: (err: any) => {

--- a/frontend/src/pages/CsvUploadPage.tsx
+++ b/frontend/src/pages/CsvUploadPage.tsx
@@ -60,9 +60,29 @@ export const CsvUploadPage = () => {
     setError(null);
     
     try {
-      // プレビューしたデータをデータベースに保存
+      // すべての必要なフィールドを明示的にマッピング（キャメルケースを使用）
+      const mappedStatements = cardStatementSummaries.map(statement => ({
+        type: statement.type || "発生",
+        statementNo: statement.statementNo || 0,
+        cardType: cardType,
+        description: statement.description || "",
+        useDate: statement.useDate || "",
+        paymentDate: statement.paymentDate || "",
+        paymentMonth: statement.paymentMonth || "",
+        amount: Number(statement.amount) || 0,
+        totalChargeAmount: Number(statement.totalChargeAmount) || 0,
+        chargeAmount: Number(statement.chargeAmount) || 0,
+        remainingBalance: Number(statement.remainingBalance) || 0,
+        paymentCount: Number(statement.paymentCount) || 0,
+        installmentCount: Number(statement.installmentCount) || 0,
+        annualRate: Number(statement.annualRate) || 0,
+        monthlyRate: Number(statement.monthlyRate) || 0,
+      }));
+      
+      console.log('送信するデータ:', JSON.stringify(mappedStatements, null, 2));
+      
       const result = await saveCardStatementsMutation.mutateAsync({
-        cardStatements: cardStatementSummaries,
+        cardStatements: mappedStatements,
         cardType: cardType
       });
       


### PR DESCRIPTION
## 概要
### 集計用レコードの生成機能のフロントエンド-バックエンド間の連携不整合を修正

CSVアップロード画面でCSVをアップロードした際に、
フロントエンドからバックエンドへ送信されるデータの形式に不整合があり、正しい集計用データが生成されていなかった。

## 変更内容
- `cardStatements.ts` の `saveCardStatements` 関数を修正
- `useMutateCardStatements.ts` のミューテーション処理を最適化
- `CsvUploadPage.tsx` のデータ保存処理を簡素化

## テスト方法
1. CSVアップロード画面でCSVファイルをアップロード
2. プレビューデータが正しく表示されることを確認
3. 「データを保存する」ボタンをクリックして保存
4. 保存されたデータが正しく表示されることを確認

close #21