### PR TITLE
feature/frontend/集計用データの表示画面の実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { TaskManagerPage } from './pages/TaskManagerPage'
 import { CsvUploadPage } from './pages/CsvUploadPage'
 import axios from 'axios'
 import { CsrfToken } from './types'
+import { CardStatementsPage } from './pages/CardStatementsPage'
 
 function App() {
   useEffect(() => {
@@ -23,6 +24,7 @@ function App() {
         <Route path="/" element={<AuthPage />} />
         <Route path="/task-manager" element={<TaskManagerPage />} />
         <Route path="/csv-upload" element={<CsvUploadPage />} />
+        <Route path="/card-statements-page" element={<CardStatementsPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/components/card-statements-page/CardStatementFilter.tsx
+++ b/frontend/src/components/card-statements-page/CardStatementFilter.tsx
@@ -1,0 +1,125 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  Box, 
+  FormControl, 
+  InputLabel, 
+  Select, 
+  MenuItem, 
+  Button, 
+  Grid,
+  SelectChangeEvent
+} from '@mui/material';
+import { CardStatementSummary } from '../../types/models/cardStatement';
+
+interface CardStatementFilterProps {
+  onFilter: (month: string, cardType: string) => void;
+  cardStatements: CardStatementSummary[];
+}
+
+export const CardStatementFilter: React.FC<CardStatementFilterProps> = ({ 
+  onFilter,
+  cardStatements
+}) => {
+  const [month, setMonth] = useState('');
+  const [cardType, setCardType] = useState('');
+  const [availableMonths, setAvailableMonths] = useState<string[]>([]);
+  const [availableCardTypes, setAvailableCardTypes] = useState<string[]>([]);
+
+  // 利用可能な支払月とカード種類を抽出
+  useEffect(() => {
+    if (cardStatements.length > 0) {
+      // 支払月の一覧を取得（重複を除去）
+      const months = Array.from(new Set(
+        cardStatements.map(statement => statement.paymentMonth)
+      )).sort().reverse(); // 新しい月順にソート
+      
+      // カード種類の一覧を取得（重複を除去）
+      const cardTypes = Array.from(new Set(
+        cardStatements.map(statement => statement.cardType)
+      )).sort();
+      
+      setAvailableMonths(months);
+      setAvailableCardTypes(cardTypes);
+    }
+  }, [cardStatements]);
+
+  const handleMonthChange = (event: SelectChangeEvent) => {
+    setMonth(event.target.value);
+  };
+
+  const handleCardTypeChange = (event: SelectChangeEvent) => {
+    setCardType(event.target.value);
+  };
+
+  const handleFilter = () => {
+    onFilter(month, cardType);
+  };
+
+  const handleClear = () => {
+    setMonth('');
+    setCardType('');
+    onFilter('', '');
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Grid container spacing={2} alignItems="center">
+        <Grid item xs={12} sm={4}>
+          <FormControl fullWidth>
+            <InputLabel id="month-select-label">支払月</InputLabel>
+            <Select
+              labelId="month-select-label"
+              id="month-select"
+              value={month}
+              label="支払月"
+              onChange={handleMonthChange}
+            >
+              <MenuItem value="">すべて</MenuItem>
+              {availableMonths.map((m) => (
+                <MenuItem key={m} value={m}>{m}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        
+        <Grid item xs={12} sm={4}>
+          <FormControl fullWidth>
+            <InputLabel id="card-type-select-label">カード種類</InputLabel>
+            <Select
+              labelId="card-type-select-label"
+              id="card-type-select"
+              value={cardType}
+              label="カード種類"
+              onChange={handleCardTypeChange}
+            >
+              <MenuItem value="">すべて</MenuItem>
+              {availableCardTypes.map((type) => (
+                <MenuItem key={type} value={type}>{type}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        
+        <Grid item xs={12} sm={4}>
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <Button 
+              variant="contained" 
+              color="primary" 
+              onClick={handleFilter}
+              fullWidth
+            >
+              フィルター適用
+            </Button>
+            <Button 
+              variant="outlined" 
+              onClick={handleClear}
+              fullWidth
+            >
+              クリア
+            </Button>
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};

--- a/frontend/src/components/card-statements-page/CardStatementList.tsx
+++ b/frontend/src/components/card-statements-page/CardStatementList.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableContainer, 
+  TableHead, 
+  TableRow, 
+  Paper, 
+  TablePagination,
+  Typography,
+  Box,
+  Chip,
+  Tooltip
+} from '@mui/material';
+import { CardStatementSummary } from '../../types/models/cardStatement';
+
+interface CardStatementListProps {
+  cardStatements: CardStatementSummary[];
+  filterMonth: string;
+  filterCardType: string;
+}
+
+export const CardStatementList: React.FC<CardStatementListProps> = ({ 
+  cardStatements,
+  filterMonth,
+  filterCardType
+}) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  // ページネーション処理
+  const handleChangePage = (event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  // 合計金額の計算
+  const totalAmount = cardStatements.reduce((sum, statement) => sum + statement.amount, 0);
+
+  // 日付のフォーマット関数
+  const formatDate = (dateString: string) => {
+    if (!dateString) return '';
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleString('ja-JP');
+    } catch (e) {
+      return dateString;
+    }
+  };
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="h6">
+          {filterMonth && <Chip label={`支払月: ${filterMonth}`} sx={{ mr: 1 }} />}
+          {filterCardType && <Chip label={`カード: ${filterCardType}`} />}
+        </Typography>
+        <Typography variant="h6">
+          合計金額: {totalAmount.toLocaleString()}円
+        </Typography>
+      </Box>
+      
+      <TableContainer component={Paper}>
+        <Table sx={{ minWidth: 650 }} aria-label="カード明細テーブル" size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>種別</TableCell>
+              <TableCell>明細No</TableCell>
+              <TableCell>カード種類</TableCell>
+              <TableCell>説明</TableCell>
+              <TableCell>利用日</TableCell>
+              <TableCell>支払日</TableCell>
+              <TableCell>支払月</TableCell>
+              <TableCell align="right">金額</TableCell>
+              <TableCell align="right">総請求額</TableCell>
+              <TableCell align="right">手数料</TableCell>
+              <TableCell align="right">残高</TableCell>
+              <TableCell align="right">支払回数</TableCell>
+              <TableCell align="right">分割回数</TableCell>
+              <TableCell align="right">年率(%)</TableCell>
+              <TableCell align="right">月率(%)</TableCell>
+              <TableCell>登録日時</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {cardStatements
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((statement, index) => (
+                <TableRow
+                  key={statement.id || index}
+                  sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                >
+                  <TableCell>{statement.type}</TableCell>
+                  <TableCell>{statement.statementNo}</TableCell>
+                  <TableCell>{statement.cardType}</TableCell>
+                  <Tooltip title={statement.description} arrow>
+                    <TableCell sx={{ maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {statement.description}
+                    </TableCell>
+                  </Tooltip>
+                  <TableCell>{statement.useDate}</TableCell>
+                  <TableCell>{statement.paymentDate}</TableCell>
+                  <TableCell>{statement.paymentMonth}</TableCell>
+                  <TableCell align="right">{statement.amount.toLocaleString()}</TableCell>
+                  <TableCell align="right">{statement.totalChargeAmount.toLocaleString()}</TableCell>
+                  <TableCell align="right">{statement.chargeAmount.toLocaleString()}</TableCell>
+                  <TableCell align="right">{statement.remainingBalance.toLocaleString()}</TableCell>
+                  <TableCell align="right">{statement.paymentCount}</TableCell>
+                  <TableCell align="right">{statement.installmentCount}</TableCell>
+                  <TableCell align="right">{(statement.annualRate * 100).toFixed(2)}</TableCell>
+                  <TableCell align="right">{(statement.monthlyRate * 100).toFixed(4)}</TableCell>
+                  <TableCell>{formatDate(statement.created_at || '')}</TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      
+      <TablePagination
+        rowsPerPageOptions={[5, 10, 25, 50]}
+        component="div"
+        count={cardStatements.length}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        labelRowsPerPage="表示件数:"
+        labelDisplayedRows={({ from, to, count }) => `${from}-${to} / ${count}`}
+      />
+    </Box>
+  );
+};

--- a/frontend/src/components/card-statements-page/index.ts
+++ b/frontend/src/components/card-statements-page/index.ts
@@ -1,0 +1,2 @@
+export { CardStatementList } from './CardStatementList';
+export { CardStatementFilter } from './CardStatementFilter';

--- a/frontend/src/pages/CardStatementsPage.tsx
+++ b/frontend/src/pages/CardStatementsPage.tsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import { Container, Typography, Box, Paper, CircularProgress, Alert } from '@mui/material';
+import { useQueryCardStatements } from '../hooks/queryHooks/useQueryCardStatements';
+import { CardStatementList } from '../components/card-statements-page/CardStatementList';
+import { CardStatementFilter } from '../components/card-statements-page/CardStatementFilter';
+import { CardStatementSummary } from '../types/models/cardStatement';
+
+export const CardStatementsPage = () => {
+  const { data: cardStatements, isLoading, error } = useQueryCardStatements();
+  const [filteredStatements, setFilteredStatements] = useState<CardStatementSummary[]>([]);
+  const [filterMonth, setFilterMonth] = useState<string>('');
+  const [filterCardType, setFilterCardType] = useState<string>('');
+
+  // データが取得できたらフィルタリング用のステートを更新
+  useEffect(() => {
+    if (cardStatements) {
+      setFilteredStatements(cardStatements);
+    }
+  }, [cardStatements]);
+
+  // フィルタリング処理
+  const handleFilter = (month: string, cardType: string) => {
+    setFilterMonth(month);
+    setFilterCardType(cardType);
+    
+    if (!cardStatements) return;
+    
+    let filtered = [...cardStatements];
+    
+    if (month) {
+      filtered = filtered.filter(statement => statement.paymentMonth.includes(month));
+    }
+    
+    if (cardType) {
+      filtered = filtered.filter(statement => statement.cardType === cardType);
+    }
+    
+    setFilteredStatements(filtered);
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        カード明細一覧
+      </Typography>
+      
+      <Paper sx={{ p: 2, mb: 3 }}>
+        <CardStatementFilter 
+          onFilter={handleFilter}
+          cardStatements={cardStatements || []}
+        />
+      </Paper>
+      
+      <Box sx={{ mt: 3 }}>
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+            <CircularProgress />
+          </Box>
+        ) : error ? (
+          <Alert severity="error">
+            データの取得中にエラーが発生しました: {error.message}
+          </Alert>
+        ) : filteredStatements.length === 0 ? (
+          <Alert severity="info">
+            表示するカード明細データがありません。CSVアップロードページからデータを登録してください。
+          </Alert>
+        ) : (
+          <CardStatementList 
+            cardStatements={filteredStatements} 
+            filterMonth={filterMonth}
+            filterCardType={filterCardType}
+          />
+        )}
+      </Box>
+    </Container>
+  );
+};


### PR DESCRIPTION
## 概要
### カード明細一覧画面の実装
カードの明細データを一覧表示し、フィルタリング機能を提供する画面を実装しました。
ユーザーは支払月やカード種類でデータをフィルタリングでき、明細の合計金額も確認できます。

## 変更内容

### 新規ファイル
- `frontend/src/components/card-statements-page/CardStatementList.tsx`
- `frontend/src/components/card-statements-page/CardStatementFilter.tsx`
- `frontend/src/components/card-statements-page/index.ts`
- `frontend/src/pages/CardStatementsPage.tsx`

### 変更ファイル
- `frontend/src/App.tsx` - 新しいルートを追加

## 実装詳細
### カード明細リスト (`CardStatementList.tsx`)
- Material UIのTableコンポーネントを使用した明細の表形式表示
- ページネーション機能の実装
- 明細の合計金額表示
- 長いテキストはツールチップで全文表示
- 日付のフォーマット処理

### フィルターコンポーネント (`CardStatementFilter.tsx`)
- 支払月とカード種類による絞り込み機能
- 利用可能な支払月とカード種類を動的に表示
- フィルターのクリア機能

### カード明細ページ (`CardStatementsPage.tsx`)
- カード明細データの取得と状態管理
- フィルタリングロジックの実装
- ローディング状態とエラー表示
- データがない場合のメッセージ表示

### ルーティング追加 (`App.tsx`)
- `/card-statements-page` へのルートを追加

## 動作確認項目
- カード明細データが正しく表示される
- 支払月でフィルタリングできる
- カード種類でフィルタリングできる
- フィルターをクリアできる
- 合計金額が正しく計算される
- ページネーションが正しく動作する
- データがない場合の表示が適切
- レスポンシブデザインの確認

## 今後の改善点
- カード明細の詳細表示機能
- CSVエクスポート機能
- グラフによるデータ可視化
- カテゴリ別集計機能

## 関連
close #23