### PR TITLE
feature-modify/backend > レスポンス型にyear・monthを追加

### DIFF
--- a/backend/controller/card_statement_controller.go
+++ b/backend/controller/card_statement_controller.go
@@ -232,6 +232,11 @@ func (csc *cardStatementController) SaveCardStatements(c echo.Context) error {
 	
 	request.UserId = userId
 	
+	// Ensure year and month are valid
+	if request.Year < 0 || request.Month < 1 || request.Month > 12 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid year or month"})
+	}
+	
 	// カード明細の保存
 	cardStatementsRes, err := csc.csu.SaveCardStatements(request)
 	if err != nil {

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1267,7 +1267,9 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "card_statements",
-                "card_type"
+                "card_type",
+                "month",
+                "year"
             ],
             "properties": {
                 "card_statements": {
@@ -1279,6 +1281,16 @@ const docTemplate = `{
                 "card_type": {
                     "type": "string",
                     "example": "rakuten"
+                },
+                "month": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1,
+                    "example": 4
+                },
+                "year": {
+                    "type": "integer",
+                    "example": 2023
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1264,7 +1264,9 @@
             "type": "object",
             "required": [
                 "card_statements",
-                "card_type"
+                "card_type",
+                "month",
+                "year"
             ],
             "properties": {
                 "card_statements": {
@@ -1276,6 +1278,16 @@
                 "card_type": {
                     "type": "string",
                     "example": "rakuten"
+                },
+                "month": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1,
+                    "example": 4
+                },
+                "year": {
+                    "type": "integer",
+                    "example": 2023
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -122,9 +122,19 @@ definitions:
       card_type:
         example: rakuten
         type: string
+      month:
+        example: 4
+        maximum: 12
+        minimum: 1
+        type: integer
+      year:
+        example: 2023
+        type: integer
     required:
     - card_statements
     - card_type
+    - month
+    - year
     type: object
   model.CardStatementSummary:
     properties:

--- a/backend/model/card_statement.go
+++ b/backend/model/card_statement.go
@@ -132,6 +132,8 @@ type CardStatementPreviewRequest struct {
 type CardStatementSaveRequest struct {
 	CardStatements []CardStatementSummary `json:"card_statements" validate:"required"`
 	CardType       string                 `json:"card_type" validate:"required" example:"rakuten"`
+	Year           int                    `json:"year" validate:"required" example:"2023"`
+	Month          int                    `json:"month" validate:"required,min=1,max=12" example:"4"`
 	UserId         uint                   `json:"-"`
 }
 // CardStatementByMonthRequest 支払月ごとのカード明細取得リクエスト


### PR DESCRIPTION
## 概要
### 集計用データのカード明細保存時に支払年・支払い月をリクエストとして送信するように修正
カード明細の保存時にフロントエンドで選択された支払年と支払い月をリクエストとして送信するように修正

### 修正内容
1. **モデルの修正**
   - `backend/model/card_statement.go` にて、`CardStatementSaveRequest` 構造体に `Year` と `Month` フィールドを追加しました。

2. **コントローラの修正**
   - `backend/controller/card_statement_controller.go` の `SaveCardStatements` メソッドで、リクエストから `Year` と `Month` を取得し、バリデーションを追加。

3. **ドキュメントの修正**
   - `backend/docs/docs.go`、`backend/docs/swagger.json`、`backend/docs/swagger.yaml` を更新し、APIドキュメントに `Year` と `Month` が含まれることを明記。

### 変更したファイル
- `backend/model/card_statement.go`
- `backend/controller/card_statement_controller.go`
- `backend/docs/docs.go`
- `backend/docs/swagger.json`
- `backend/docs/swagger.yaml`

### テスト
- フロントエンドからのリクエストに支払年と支払い月が含まれることを確認。
- バックエンドでこれらの情報が適切に処理されることを確認。
- APIドキュメントが最新の状態に更新されていることを確認。

### 関連するIssue
- close #28 