### PR TITLE
feature/frontend > 年月のページネーションを実装

### DIFF
--- a/frontend/src/api/csvHistories.ts
+++ b/frontend/src/api/csvHistories.ts
@@ -21,18 +21,16 @@ export const fetchCSVHistoryById = async (id: number): Promise<CSVHistoryDetailR
 };
 
 // CSV履歴を保存
-export const saveCSVHistory = async (file: File, fileName: string, cardType: CardType): Promise<CSVHistoryResponse> => {
-  const formData = new FormData();
-  formData.append('file', file);
-  formData.append('file_name', fileName);
-  formData.append('card_type', cardType);
-
-  const response = await axios.post<CSVHistoryResponse>(`${API_URL}/csv-histories`, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
-    withCredentials: true,
-  });
+export const saveCSVHistory = async (formData: FormData) => {
+  const response = await axios.post(
+    `${process.env.REACT_APP_API_URL}/csv-histories`,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
   return response.data;
 };
 

--- a/frontend/src/components/csv-upload-page/CSVHistorySaver.tsx
+++ b/frontend/src/components/csv-upload-page/CSVHistorySaver.tsx
@@ -4,22 +4,23 @@ import { CardTypeSelector } from './CardTypeSelector';
 import { CardType } from '../../types/cardType';
 import { useMutateCsvHistories } from '../../hooks/mutateHooks/useMutateCsvHistories';
 
-interface CSVHistorySaverProps {
-  file: File | null;
-}
+type Props = {
+  file: File;
+  year: number;
+  month: number;
+  cardType: CardType;
+};
 
-export const CSVHistorySaver: React.FC<CSVHistorySaverProps> = ({ file }) => {
+export const CSVHistorySaver: React.FC<Props> = ({ file, year, month, cardType: initialCardType }) => {
   const [open, setOpen] = useState(false);
-  const [fileName, setFileName] = useState('');
-  const [cardType, setCardType] = useState<CardType>('rakuten');
+  const [fileName, setFileName] = useState(file.name);
+  const [cardType, setCardType] = useState<CardType>(initialCardType);
   const { saveCSVHistoryMutation } = useMutateCsvHistories();
   const isLoading = saveCSVHistoryMutation.isLoading;
 
   const handleOpen = () => {
-    if (file) {
-      setFileName(file.name); // デフォルトでファイル名をセット
-      setOpen(true);
-    }
+    setFileName(file.name); // デフォルトでファイル名をセット
+    setOpen(true);
   };
 
   const handleClose = () => {
@@ -33,7 +34,9 @@ export const CSVHistorySaver: React.FC<CSVHistorySaverProps> = ({ file }) => {
       await saveCSVHistoryMutation.mutateAsync({
         file,
         fileName,
-        cardType
+        cardType,
+        year,
+        month,
       });
       handleClose();
     } catch (error) {

--- a/frontend/src/components/csv-upload-page/MonthSelector.tsx
+++ b/frontend/src/components/csv-upload-page/MonthSelector.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Box, IconButton, Typography } from '@mui/material';
+
+type Props = {
+  month: number;
+  setMonth: (month: number) => void;
+};
+
+export const MonthSelector: React.FC<Props> = ({ month, setMonth }) => (
+  <Box display="flex" justifyContent="center" mb={2} flexWrap="wrap" gap={1}>
+    {[...Array(12)].map((_, i) => {
+      const m = i + 1;
+      const isSelected = month === m;
+      return (
+        <IconButton
+          key={m}
+          onClick={() => setMonth(m)}
+          sx={{
+            borderRadius: '50%',
+            width: 48,
+            height: 48,
+            backgroundColor: isSelected ? 'primary.main' : 'grey.200',
+            color: isSelected ? 'white' : 'text.primary',
+            border: isSelected ? '2px solid' : '1px solid',
+            borderColor: isSelected ? 'primary.dark' : 'grey.300',
+            transition: 'background 0.2s, color 0.2s',
+            '&:hover': {
+              backgroundColor: isSelected ? 'primary.dark' : 'grey.300',
+            },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            p: 0,
+          }}
+        >
+          <Box display="flex" alignItems="center" justifyContent="center">
+            <Typography
+              component="span"
+              sx={{
+                fontSize: 22,
+                fontWeight: isSelected ? 'bold' : 'normal',
+                lineHeight: 1,
+              }}
+            >
+              {m}
+            </Typography>
+            <Typography
+              component="span"
+              sx={{
+                fontSize: 13,
+                lineHeight: 1,
+                fontWeight: 'normal',
+                letterSpacing: 0,
+                ml: 0.2,
+              }}
+            >
+              月
+            </Typography>
+          </Box>
+        </IconButton>
+      );
+    })}
+  </Box>
+);

--- a/frontend/src/components/csv-upload-page/YearPagination.tsx
+++ b/frontend/src/components/csv-upload-page/YearPagination.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { IconButton, Typography, Box } from '@mui/material';
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+
+type Props = {
+  year: number;
+  setYear: (year: number) => void;
+};
+
+export const YearPagination: React.FC<Props> = ({ year, setYear }) => (
+  <Box display="flex" alignItems="center" justifyContent="center" mb={2}>
+    <IconButton onClick={() => setYear(year - 1)}>
+      <ArrowBackIosIcon />
+    </IconButton>
+    <Typography variant="h6" sx={{ mx: 2 }}>{year}年</Typography>
+    <IconButton onClick={() => setYear(year + 1)}>
+      <ArrowForwardIosIcon />
+    </IconButton>
+  </Box>
+);

--- a/frontend/src/components/csv-upload-page/index.ts
+++ b/frontend/src/components/csv-upload-page/index.ts
@@ -1,3 +1,5 @@
+export { YearPagination } from './YearPagination';
+export { MonthSelector } from './MonthSelector';
 export { Header } from './Header';
 export { Instructions } from './Instructions';
 export { FileUploader } from './FileUploader';

--- a/frontend/src/hooks/mutateHooks/useMutateCardStatements.ts
+++ b/frontend/src/hooks/mutateHooks/useMutateCardStatements.ts
@@ -19,22 +19,22 @@ export const useMutateCardStatements = () => {
     },
   });
 
-  // 新しいプレビューミューテーション
+  // 年・月を受け取るように修正
   const previewCSVMutation = useMutation({
-    mutationFn: ({ file, cardType }: { file: File, cardType: CardType }) => 
-      previewCSV(file, cardType),
+    mutationFn: ({ file, cardType, year, month }: { file: File, cardType: CardType, year: number, month: number }) => 
+      previewCSV(file, cardType, year, month),
     onError: (err: any) => {
       console.error('CSVプレビューエラー:', err);
       throw err;
     },
   });
 
-  // 保存ミューテーション
+  // 年・月を受け取るように修正
   const saveCardStatementsMutation = useMutation({
-    mutationFn: ({ cardStatements, cardType }: { cardStatements: CardStatementSummary[], cardType: CardType }) => {
+    mutationFn: ({ cardStatements, cardType, year, month }: { cardStatements: CardStatementSummary[], cardType: CardType, year: number, month: number }) => {
       console.log('保存するデータ（変換前）:', JSON.stringify(cardStatements, null, 2));
       console.log('カード種類:', cardType);
-      return saveCardStatements(cardStatements, cardType);
+      return saveCardStatements(cardStatements, cardType, year, month);
     },
     onSuccess: (data) => {
       console.log('保存成功:', JSON.stringify(data, null, 2));

--- a/frontend/src/hooks/mutateHooks/useMutateCsvHistories.ts
+++ b/frontend/src/hooks/mutateHooks/useMutateCsvHistories.ts
@@ -7,8 +7,27 @@ export const useMutateCsvHistories = () => {
 
   // CSV履歴保存ミューテーション
   const saveCSVHistoryMutation = useMutation({
-    mutationFn: ({ file, fileName, cardType }: { file: File, fileName: string, cardType: CardType }) => 
-      saveCSVHistory(file, fileName, cardType),
+    mutationFn: async ({
+      file,
+      fileName,
+      cardType,
+      year,
+      month,
+    }: {
+      file: File;
+      fileName: string;
+      cardType: CardType;
+      year: number;
+      month: number;
+    }) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('file_name', fileName);
+      formData.append('card_type', cardType);
+      formData.append('year', String(year));
+      formData.append('month', String(month));
+      return saveCSVHistory(formData);
+    },
     onSuccess: () => {
       // 成功時にCSV履歴一覧を再取得
       queryClient.invalidateQueries({ queryKey: ['csvHistories'] });

--- a/frontend/src/hooks/queryHooks/useQueryCardStatementsByMonth.ts
+++ b/frontend/src/hooks/queryHooks/useQueryCardStatementsByMonth.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { CardStatementSummary } from '../../types/models/cardStatement';
+
+// バックエンドのレスポンスをフロントエンドの型に変換するヘルパー関数
+function mapResponseToSummary(item: any): CardStatementSummary & { year: number, month: number } {
+  return {
+    type: item.type || '',
+    statementNo: item.statement_no || 0,
+    cardType: item.card_type || '',
+    description: item.description || '',
+    useDate: item.use_date || '',
+    paymentDate: item.payment_date || '',
+    paymentMonth: item.payment_month || '',
+    amount: item.amount || 0,
+    totalChargeAmount: item.total_charge_amount || 0,
+    chargeAmount: item.charge_amount || 0,
+    remainingBalance: item.remaining_balance || 0,
+    paymentCount: item.payment_count || 0,
+    installmentCount: item.installment_count || 0,
+    annualRate: item.annual_rate || 0,
+    monthlyRate: item.monthly_rate || 0,
+    id: item.id,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    // year/monthはCardStatementSummary型に追加する必要があります
+    year: item.year,
+    month: item.month
+  };
+}
+
+function mapResponseToSummaries(items: any[]): (CardStatementSummary & { year: number, month: number })[] {
+  return items.map(mapResponseToSummary);
+}
+
+export const useQueryCardStatementsByMonth = (year: number, month: number) => {
+  return useQuery<(CardStatementSummary & { year: number, month: number })[], Error>({
+    queryKey: ['cardStatements', 'byMonth', year, month],
+    queryFn: async () => {
+      if (!year || !month) return [];
+      
+      const response = await axios.get(
+        `${process.env.REACT_APP_API_URL}/card-statements/by-month`, {
+          params: { year, month }
+        }
+      );
+      return mapResponseToSummaries(response.data);
+    },
+    enabled: !!year && !!month && year > 0 && month >= 1 && month <= 12,
+  });
+};

--- a/frontend/src/hooks/queryHooks/useQueryCsvHistoriesByMonth.ts
+++ b/frontend/src/hooks/queryHooks/useQueryCsvHistoriesByMonth.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export interface CsvHistoryResponse {
+  id: number;
+  file_name: string;
+  card_type: string;
+  created_at: string;
+  updated_at: string;
+  year: number;
+  month: number;
+}
+
+export const useQueryCsvHistoriesByMonth = (year: number, month: number) => {
+  return useQuery<CsvHistoryResponse[], Error>({
+    queryKey: ['csvHistories', 'byMonth', year, month],
+    queryFn: async () => {
+      if (!year || !month) return [];
+      
+      const response = await axios.get(
+        `${process.env.REACT_APP_API_URL}/csv-histories/by-month`, {
+          params: { year, month }
+        }
+      );
+      return response.data;
+    },
+    enabled: !!year && !!month && year > 0 && month >= 1 && month <= 12,
+  });
+};

--- a/frontend/src/store/slices/cardStatementSlice.ts
+++ b/frontend/src/store/slices/cardStatementSlice.ts
@@ -1,12 +1,17 @@
 import { StateCreator } from 'zustand';
 import { CardStatementState, EditedCardStatement, CardStatementSummary, initialEditedCardStatement } from '../../types/models/cardStatement';
 
+const currentYear = new Date().getFullYear();
+const currentMonth = new Date().getMonth() + 1;
+
 /**
  * カード明細関連のZustandストアスライス
  */
 export const createCardStatementSlice: StateCreator<CardStatementState> = (set) => ({
   editedCardStatement: initialEditedCardStatement,
   cardStatementSummaries: [],
+  selectedYear: currentYear,
+  selectedMonth: currentMonth,
   updateEditedCardStatement: (payload: EditedCardStatement) => set({
     editedCardStatement: payload
   }),
@@ -16,4 +21,6 @@ export const createCardStatementSlice: StateCreator<CardStatementState> = (set) 
   resetEditedCardStatement: () => set({ 
     editedCardStatement: initialEditedCardStatement 
   }),
+  setSelectedYear: (year: number) => set({ selectedYear: year }),
+  setSelectedMonth: (month: number) => set({ selectedMonth: month }),
 });

--- a/frontend/src/store/state/cardStatementState.ts
+++ b/frontend/src/store/state/cardStatementState.ts
@@ -4,16 +4,27 @@ import { EditedCardStatement, CardStatementSummary } from '../../types/models/ca
 export type CardStatementState = {
   editedCardStatement: EditedCardStatement;
   cardStatementSummaries: CardStatementSummary[];
+  selectedYear: number;
+  selectedMonth: number;
   updateEditedCardStatement: (payload: EditedCardStatement) => void;
   setCardStatementSummaries: (summaries: CardStatementSummary[]) => void;
   resetEditedCardStatement: () => void;
+  setSelectedYear: (year: number) => void;
+  setSelectedMonth: (month: number) => void;
 }
 
 // CardStatementState の初期状態
+const currentYear = new Date().getFullYear();
+const currentMonth = new Date().getMonth() + 1;
+
 export const initialCardStatementState: CardStatementState = {
   editedCardStatement: { id: 0, csvContent: '' },
   cardStatementSummaries: [],
+  selectedYear: currentYear,
+  selectedMonth: currentMonth,
   updateEditedCardStatement: () => {},
   setCardStatementSummaries: () => {},
   resetEditedCardStatement: () => {},
+  setSelectedYear: () => {},
+  setSelectedMonth: () => {},
 }

--- a/frontend/src/types/models/cardStatement.ts
+++ b/frontend/src/types/models/cardStatement.ts
@@ -50,7 +50,11 @@ export const initialEditedCardStatement: EditedCardStatement = {
 export interface CardStatementState {
   editedCardStatement: EditedCardStatement;
   cardStatementSummaries: CardStatementSummary[];
+  selectedYear: number;
+  selectedMonth: number;
   updateEditedCardStatement: (payload: EditedCardStatement) => void;
   setCardStatementSummaries: (summaries: CardStatementSummary[]) => void;
   resetEditedCardStatement: () => void;
+  setSelectedYear: (year: number) => void;
+  setSelectedMonth: (month: number) => void;
 }


### PR DESCRIPTION
## 概要
### CSV履歴と集計データを年月ごとに管理できるように改善
CSVアップロードと履歴管理を年月ごとに行えるように機能を拡張。
これによりユーザーは特定の年月を選択し、その期間に関連するCSVデータをアップロード・管理できるようになる。

## 変更内容
- 年のページネーション機能を追加
- 月のセレクター機能を追加
- CSVアップロードを選択した年月に関連付け
- CSV履歴を年月ごとに表示
- 集計データを年月ごとに管理

## テスト内容
- 年月の切り替え機能が正常に動作することを確認
- 選択した年月に対してCSVデータが正しくアップロードされることを確認
- 年月ごとのCSV履歴が正しく表示されることを確認
- 年月ごとの集計データが正しく表示されることを確認

## 関連Issue
Closes #25 
