### PR TITLE
feature/backend-and-frontend/認証状態に基づくルーティング制御の実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -15,6 +15,43 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/auth-verify": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "ユーザーの認証状態を確認し、認証済みの場合はユーザー情報を返す",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "認証状態の確認",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.AuthVerifyResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/card-statements": {
             "get": {
                 "description": "ログインユーザーのすべてのカード明細を取得する",
@@ -1110,6 +1147,18 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "model.AuthVerifyResponse": {
+            "type": "object",
+            "properties": {
+                "authenticated": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "user": {
+                    "$ref": "#/definitions/model.UserResponse"
+                }
+            }
+        },
         "model.CSVHistoryDetailResponse": {
             "type": "object",
             "properties": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12,6 +12,43 @@
     "host": "localhost:8080",
     "basePath": "/",
     "paths": {
+        "/auth-verify": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "ユーザーの認証状態を確認し、認証済みの場合はユーザー情報を返す",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "認証状態の確認",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.AuthVerifyResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/card-statements": {
             "get": {
                 "description": "ログインユーザーのすべてのカード明細を取得する",
@@ -1107,6 +1144,18 @@
         }
     },
     "definitions": {
+        "model.AuthVerifyResponse": {
+            "type": "object",
+            "properties": {
+                "authenticated": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "user": {
+                    "$ref": "#/definitions/model.UserResponse"
+                }
+            }
+        },
         "model.CSVHistoryDetailResponse": {
             "type": "object",
             "properties": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,5 +1,13 @@
 basePath: /
 definitions:
+  model.AuthVerifyResponse:
+    properties:
+      authenticated:
+        example: true
+        type: boolean
+      user:
+        $ref: '#/definitions/model.UserResponse'
+    type: object
   model.CSVHistoryDetailResponse:
     properties:
       card_type:
@@ -254,6 +262,29 @@ info:
   title: Blog CMS API
   version: "1.0"
 paths:
+  /auth-verify:
+    get:
+      consumes:
+      - application/json
+      description: ユーザーの認証状態を確認し、認証済みの場合はユーザー情報を返す
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.AuthVerifyResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - Bearer: []
+      summary: 認証状態の確認
+      tags:
+      - users
   /card-statements:
     get:
       consumes:

--- a/backend/model/user.go
+++ b/backend/model/user.go
@@ -49,3 +49,9 @@ func (u *User) ToUserResponse() UserResponse {
 		Email: u.Email,
 	}
 }
+
+// AuthVerifyResponse は認証状態確認のレスポンス
+type AuthVerifyResponse struct {
+	Authenticated bool         `json:"authenticated" example:"true"`
+	User          UserResponse `json:"user,omitempty"`
+}

--- a/backend/repository/user_repository.go
+++ b/backend/repository/user_repository.go
@@ -9,6 +9,7 @@ import (
 type IUserRepository interface {
 	GetUserByEmail(email string) (*model.User, error)
 	CreateUser(user *model.User) error
+	GetUserById(id uint) (*model.User, error) // 追加
 }
 
 type userRepository struct {
@@ -29,4 +30,12 @@ func (ur *userRepository) GetUserByEmail(email string) (*model.User, error) {
 
 func (ur *userRepository) CreateUser(user *model.User) error {
 	return ur.db.Create(user).Error
+}
+
+func (ur *userRepository) GetUserById(id uint) (*model.User, error) {
+	user := &model.User{}
+	if err := ur.db.First(user, id).Error; err != nil {
+		return nil, err
+	}
+	return user, nil
 }

--- a/backend/router/routes/auth.go
+++ b/backend/router/routes/auth.go
@@ -2,13 +2,20 @@ package routes
 
 import (
 	"monelog/controller"
+	"monelog/utils/middleware"
 	"github.com/labstack/echo/v4"
 )
 
 // SetupAuthRoutes は認証関連のルートを設定します
 func SetupAuthRoutes(e *echo.Echo, uc controller.IUserController) {
+	// 認証不要のルート
 	e.POST("/signup", uc.SignUp)
 	e.POST("/login", uc.LogIn)
-	e.POST("/logout", uc.LogOut)
 	e.GET("/csrf-token", uc.CsrfToken)
+	e.GET("/auth-verify", uc.VerifyAuth) // JWT ミドルウェアを適用しない
+	
+	// 認証が必要なルート
+	auth := e.Group("")
+	auth.Use(middleware.GetJWTMiddleware())
+	auth.POST("/logout", uc.LogOut)
 }

--- a/backend/usecase/user_usecase.go
+++ b/backend/usecase/user_usecase.go
@@ -14,6 +14,7 @@ import (
 type IUserUsecase interface {
 	SignUp(req model.UserSignupRequest) (*model.UserResponse, error)
 	Login(req model.UserLoginRequest) (string, error)
+	VerifyAuth(userId uint) (*model.UserResponse, error) // 追加
 }
 
 type userUsecase struct {
@@ -76,4 +77,17 @@ func (uu *userUsecase) Login(req model.UserLoginRequest) (string, error) {
 	})
 	
 	return token.SignedString([]byte(os.Getenv("SECRET")))
+}
+
+// VerifyAuth は認証状態を確認し、ユーザー情報を返します
+func (uu *userUsecase) VerifyAuth(userId uint) (*model.UserResponse, error) {
+	// ユーザーIDからユーザー情報を取得
+	user, err := uu.ur.GetUserById(userId)
+	if err != nil {
+		return nil, err
+	}
+	
+	// レスポンス作成
+	response := user.ToUserResponse()
+	return &response, nil
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,14 @@
 import { useEffect } from 'react'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
 import { AuthPage } from './pages/AuthPage'
 import { TaskManagerPage } from './pages/TaskManagerPage'
 import { CsvUploadPage } from './pages/CsvUploadPage'
 import axios from 'axios'
 import { CsrfToken } from './types'
 import { CardStatementsPage } from './pages/CardStatementsPage'
+import { PublicRoute } from './components/route/PublicRoute'
+import { AuthenticatedRoute } from './components/route/AuthenticatedRoute'
+import { Layout } from './components/layout/Layout'
 
 function App() {
   useEffect(() => {
@@ -18,15 +21,30 @@ function App() {
     }
     getCsrfToken()
   }, [])
+  
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<AuthPage />} />
-        <Route path="/task-manager" element={<TaskManagerPage />} />
-        <Route path="/csv-upload" element={<CsvUploadPage />} />
-        <Route path="/card-statements-page" element={<CardStatementsPage />} />
+        {/* 未認証ユーザー向けルート */}
+        <Route element={<PublicRoute />}>
+          <Route path="/" element={<AuthPage />} />
+          <Route path="/login" element={<AuthPage />} />
+        </Route>
+        
+        {/* 認証済みユーザー向けルート */}
+        <Route element={<AuthenticatedRoute />}>
+          <Route element={<Layout />}>
+            <Route path="/task-manager" element={<TaskManagerPage />} />
+            <Route path="/csv-upload" element={<CsvUploadPage />} />
+            <Route path="/card-statements-page" element={<CardStatementsPage />} />
+          </Route>
+        </Route>
+        
+        {/* 存在しないパスへのリダイレクト */}
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   )
 }
+
 export default App

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -38,3 +38,20 @@ export const getCurrentUser = async (): Promise<User> => {
   // ログイン時に保存したユーザー情報をローカルストレージから取得するなどの対応が必要
   throw new Error('Not implemented: getCurrentUser endpoint is not available in backend');
 };
+
+// 認証状態確認のレスポンス型
+export interface AuthVerifyResponse {
+  authenticated: boolean;
+  user?: User;
+}
+
+// 認証状態を確認する関数
+export const verifyAuth = async (): Promise<AuthVerifyResponse> => {
+  try {
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}/auth-verify`);
+    return response.data;
+  } catch (error) {
+    // エラーが発生した場合は未認証状態として扱う
+    return { authenticated: false };
+  }
+};

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Box, Container, Typography, Link as MuiLink } from '@mui/material';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+
+export const Footer: React.FC = () => {
+  const { isAuthenticated } = useAuth();
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        py: 3,
+        px: 2,
+        mt: 'auto',
+        backgroundColor: (theme) => theme.palette.grey[200],
+      }}
+    >
+      <Container maxWidth="lg">
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+          <Box>
+            <Typography variant="h6" color="text.primary" gutterBottom>
+              Monelog
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              家計簿管理アプリケーション
+            </Typography>
+          </Box>
+          
+          <Box>
+            <Typography variant="h6" color="text.primary" gutterBottom>
+              リンク
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+              <MuiLink component={Link} to="/" color="inherit" underline="hover">
+                ホーム
+              </MuiLink>
+              
+              {isAuthenticated ? (
+                <>
+                  <MuiLink component={Link} to="/task-manager" color="inherit" underline="hover">
+                    タスク管理
+                  </MuiLink>
+                  <MuiLink component={Link} to="/csv-upload" color="inherit" underline="hover">
+                    CSV管理
+                  </MuiLink>
+                </>
+              ) : (
+                <>
+                  <MuiLink component={Link} to="/login" color="inherit" underline="hover">
+                    ログイン
+                  </MuiLink>
+                  <MuiLink component={Link} to="/signup" color="inherit" underline="hover">
+                    新規登録
+                  </MuiLink>
+                </>
+              )}
+            </Box>
+          </Box>
+        </Box>
+        
+        <Box mt={3}>
+          <Typography variant="body2" color="text.secondary" align="center">
+            {'Copyright © '}
+            <MuiLink component={Link} to="/" color="inherit">
+              Monelog
+            </MuiLink>{' '}
+            {currentYear}
+          </Typography>
+        </Box>
+      </Container>
+    </Box>
+  );
+};

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { AppBar, Toolbar, Typography, Button, Box, IconButton, Menu, MenuItem } from '@mui/material';
+import { AccountCircle } from '@mui/icons-material';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+import { useMutateAuth } from '../../hooks/mutateHooks/useMutateAuth';
+
+export const Header: React.FC = () => {
+  const { isAuthenticated, user } = useAuth();
+  const { logoutMutation } = useMutateAuth();
+  const navigate = useNavigate();
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLogout = () => {
+    logoutMutation.mutate();
+    handleClose();
+  };
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          <Link to="/" style={{ color: 'white', textDecoration: 'none' }}>
+            Monelog
+          </Link>
+        </Typography>
+
+        {isAuthenticated ? (
+          <Box>
+            <Button color="inherit" component={Link} to="/task-manager">
+              タスク管理
+            </Button>
+            <Button color="inherit" component={Link} to="/csv-upload">
+              CSV管理
+            </Button>
+            <IconButton
+              size="large"
+              aria-label="account of current user"
+              aria-controls="menu-appbar"
+              aria-haspopup="true"
+              onClick={handleMenu}
+              color="inherit"
+            >
+              <AccountCircle />
+            </IconButton>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
+            >
+              <MenuItem disabled>{user?.email}</MenuItem>
+              <MenuItem onClick={handleLogout}>ログアウト</MenuItem>
+            </Menu>
+          </Box>
+        ) : (
+          <Box>
+            <Button color="inherit" component={Link} to="/login">
+              ログイン
+            </Button>
+            <Button color="inherit" component={Link} to="/signup">
+              新規登録
+            </Button>
+          </Box>
+        )}
+      </Toolbar>
+    </AppBar>
+  );
+};

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { Outlet } from 'react-router-dom';
+import { Header } from './Header';
+import { Footer } from './Footer';
+
+export const Layout: React.FC = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100vh',
+      }}
+    >
+      <Header />
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          py: 3,
+        }}
+      >
+        <Outlet />
+      </Box>
+      <Footer />
+    </Box>
+  );
+};

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,0 +1,3 @@
+export { Header } from './Header';
+export { Footer } from './Footer';
+export { Layout } from './Layout';

--- a/frontend/src/components/route/AuthenticatedRoute.tsx
+++ b/frontend/src/components/route/AuthenticatedRoute.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+import { CircularProgress, Box } from '@mui/material';
+
+// 認証済みユーザーのみアクセス可能なルート
+export const AuthenticatedRoute: React.FC = () => {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // 未認証の場合はログインページにリダイレクト
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/frontend/src/components/route/PublicRoute.tsx
+++ b/frontend/src/components/route/PublicRoute.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+import { CircularProgress, Box } from '@mui/material';
+
+// 未認証ユーザーのみアクセス可能なルート（ログイン・サインアップなど）
+export const PublicRoute: React.FC = () => {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // 認証済みの場合はダッシュボードにリダイレクト
+  if (isAuthenticated) {
+    return <Navigate to="/task-manager" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/frontend/src/components/route/index.ts
+++ b/frontend/src/components/route/index.ts
@@ -1,0 +1,2 @@
+export { PublicRoute } from './PublicRoute';
+export { AuthenticatedRoute } from './AuthenticatedRoute';

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { verifyAuth } from '../api/auth';
+import useStore from '../store';
+import { User } from '../types/models/user';
+
+export const useAuth = () => {
+  const { isAuthenticated, user, isLoading, setAuth, clearAuth } = useStore();
+
+  // 認証状態を確認するクエリ
+  const { data, isLoading: isAuthLoading, refetch } = useQuery({
+    queryKey: ['auth-verify'],
+    queryFn: verifyAuth,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  // 認証状態が変わったらストアを更新
+  useEffect(() => {
+    if (!isAuthLoading && data) {
+      if (data.authenticated && data.user) {
+        // バックエンドのユーザー型をフロントエンドのユーザー型に変換
+        const frontendUser: User = {
+          id: data.user.id || 0, // id が undefined の場合は 0 を設定
+          email: data.user.email
+        };
+        setAuth(true, frontendUser);
+      } else {
+        clearAuth();
+      }
+    }
+  }, [data, isAuthLoading, setAuth, clearAuth]);
+
+  return {
+    isAuthenticated,
+    user,
+    isLoading: isLoading || isAuthLoading,
+    refetchAuth: refetch,
+  };
+};

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -4,12 +4,18 @@ import { createUserSlice } from './slices/userSlice'
 import { createTaskSlice } from './slices/taskSlice'
 import { createCardStatementSlice } from './slices/cardStatementSlice'
 import { createCSVHistorySlice } from './slices/csvHistorySlice'
+import { createAuthSlice } from './slices/authSlice'
+import { AuthState } from './state/authState'
 
-const useStore = create<State>((...args) => ({
+// ステートの型を拡張
+export type RootState = State & AuthState
+
+const useStore = create<RootState>((...args) => ({
   ...createUserSlice(...args),
   ...createTaskSlice(...args),
   ...createCardStatementSlice(...args),
   ...createCSVHistorySlice(...args),
+  ...createAuthSlice(...args),
 }))
 
 export default useStore

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -1,0 +1,19 @@
+import { StateCreator } from 'zustand';
+import { AuthState } from '../state/authState';
+import { User } from '../../types/models/user';
+
+export const createAuthSlice: StateCreator<AuthState> = (set) => ({
+  isAuthenticated: false,
+  user: null,
+  isLoading: true,
+  setAuth: (isAuthenticated: boolean, user: User | null) => set({
+    isAuthenticated,
+    user,
+    isLoading: false,
+  }),
+  clearAuth: () => set({
+    isAuthenticated: false,
+    user: null,
+    isLoading: false,
+  }),
+});

--- a/frontend/src/store/state/authState.ts
+++ b/frontend/src/store/state/authState.ts
@@ -1,0 +1,17 @@
+import { User } from '../../types/models/user';
+
+export type AuthState = {
+  isAuthenticated: boolean;
+  user: User | null;
+  isLoading: boolean;
+  setAuth: (isAuthenticated: boolean, user: User | null) => void;
+  clearAuth: () => void;
+};
+
+export const initialAuthState: AuthState = {
+  isAuthenticated: false,
+  user: null,
+  isLoading: true,
+  setAuth: () => {},
+  clearAuth: () => {},
+};


### PR DESCRIPTION
# 認証状態に基づくルーティング制御の実装

## バックエンド
### 認証状態確認エンドポイント
- `/auth-verify` エンドポイントを追加し、クッキーに保存されたJWTトークンを検証
- トークンが有効な場合はユーザー情報を返し、無効な場合は未認証状態を返す

### ユーザー認証フロー
1. ログイン時にJWTトークンを生成しクッキーに保存
2. 認証状態確認時にクッキーからトークンを取得して検証
3. ログアウト時にクッキーを無効化

## フロントエンド

### 認証状態管理
- Zustand を使用して認証状態とユーザー情報を管理
- React Query を使用して認証状態を確認するAPIを呼び出し

### ルーティング制御
- `AuthenticatedRoute`: 認証済みユーザーのみアクセス可能なルート
- `PublicRoute`: 未認証ユーザーのみアクセス可能なルート（認証済みの場合はリダイレクト）

### UI対応
- ヘッダーとフッターで認証状態に応じて表示内容を切り替え

## テスト方法
1. アプリケーションを起動し、未ログイン状態で保護されたルート（/task-manager など）にアクセスしようとすると、ログインページにリダイレクトされることを確認
2. ログイン後、ログインページにアクセスしようとすると、ダッシュボード（/task-manager）にリダイレクトされることを確認
3. ヘッダーとフッターの表示内容が認証状態に応じて適切に切り替わることを確認
4. ブラウザを更新しても認証状態が維持されることを確認


## 関連ドキュメント
- [JWT認証の実装](https://jwt.io/introduction)
- [React Routerを使用した認証フロー](https://reactrouter.com/en/main/start/overview)
- [Zustandの状態管理](https://github.com/pmndrs/zustand)
- [React Queryの使用方法](https://tanstack.com/query/latest)

##  関連issue
 - close #32 
 - close #33