### PR TITLE
refactor/backend/card_statement_controllerのモジュール化

### DIFF
--- a/backend/controller/card_statement/get_all.go
+++ b/backend/controller/card_statement/get_all.go
@@ -1,0 +1,20 @@
+package card_statement
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) GetAllCardStatements(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	cardStatementsRes, err := h.csu.GetAllCardStatements(userId)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, cardStatementsRes)
+}

--- a/backend/controller/card_statement/get_by_id.go
+++ b/backend/controller/card_statement/get_by_id.go
@@ -1,0 +1,27 @@
+package card_statement
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) GetCardStatementById(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	id := c.Param("cardStatementId")
+	cardStatementId, err := strconv.ParseUint(id, 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid card statement ID"})
+	}
+	
+	cardStatementRes, err := h.csu.GetCardStatementById(userId, uint(cardStatementId))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, cardStatementRes)
+}

--- a/backend/controller/card_statement/get_by_month.go
+++ b/backend/controller/card_statement/get_by_month.go
@@ -1,0 +1,43 @@
+package card_statement
+
+import (
+	"monelog/model"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) GetCardStatementsByMonth(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	// クエリパラメータの取得
+	yearStr := c.QueryParam("year")
+	monthStr := c.QueryParam("month")
+	
+	year, err := strconv.Atoi(yearStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid year format"})
+	}
+	
+	month, err := strconv.Atoi(monthStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid month format"})
+	}
+	
+	request := model.CardStatementByMonthRequest{
+		Year:   year,
+		Month:  month,
+		UserId: userId,
+	}
+	
+	cardStatementsRes, err := h.csu.GetCardStatementsByMonth(request)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	
+	return c.JSON(http.StatusOK, cardStatementsRes)
+}

--- a/backend/controller/card_statement/handler.go
+++ b/backend/controller/card_statement/handler.go
@@ -1,0 +1,17 @@
+package card_statement
+
+import (
+	"monelog/usecase"
+)
+
+type Handler struct {
+	csu usecase.ICardStatementUsecase
+	chu usecase.ICSVHistoryUsecase
+}
+
+func NewHandler(csu usecase.ICardStatementUsecase, chu usecase.ICSVHistoryUsecase) *Handler {
+	return &Handler{
+		csu: csu,
+		chu: chu,
+	}
+}

--- a/backend/controller/card_statement/preview_csv.go
+++ b/backend/controller/card_statement/preview_csv.go
@@ -1,0 +1,63 @@
+package card_statement
+
+import (
+	"monelog/model"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) PreviewCSV(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	// ファイルの取得
+	file, err := c.FormFile("file")
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ファイルが見つかりません"})
+	}
+	
+	// カード種類の取得
+	cardType := c.FormValue("card_type")
+	if cardType == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "card_type is required"})
+	}
+	
+	// 年月の取得（プレビュー時は任意）
+	yearStr := c.FormValue("year")
+	monthStr := c.FormValue("month")
+	
+	// 年月の変換
+	var year, month int
+	if yearStr != "" {
+		year, err = strconv.Atoi(yearStr)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid year format"})
+		}
+	}
+	
+	if monthStr != "" {
+		month, err = strconv.Atoi(monthStr)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid month format"})
+		}
+	}
+	
+	request := model.CardStatementPreviewRequest{
+		CardType: cardType,
+		UserId:   userId,
+		Year:     year,
+		Month:    month,
+	}
+	
+	// CSVのプレビュー処理
+	cardStatementsRes, err := h.csu.PreviewCSV(file, request)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	
+	return c.JSON(http.StatusOK, cardStatementsRes)
+}

--- a/backend/controller/card_statement/save_statements.go
+++ b/backend/controller/card_statement/save_statements.go
@@ -1,0 +1,43 @@
+package card_statement
+
+import (
+	"monelog/model"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) SaveCardStatements(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	var request model.CardStatementSaveRequest
+	if err := c.Bind(&request); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+	
+	request.UserId = userId
+	
+	// リクエストの検証を強化
+	if request.Year <= 0 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Year must be positive"})
+	}
+	
+	if request.Month < 1 || request.Month > 12 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Month must be between 1 and 12"})
+	}
+	
+	if len(request.CardStatements) == 0 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Card statements cannot be empty"})
+	}
+	
+	// カード明細の保存
+	cardStatementsRes, err := h.csu.SaveCardStatements(request)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	
+	return c.JSON(http.StatusCreated, cardStatementsRes)
+}

--- a/backend/controller/card_statement/upload_csv.go
+++ b/backend/controller/card_statement/upload_csv.go
@@ -1,0 +1,75 @@
+package card_statement
+
+import (
+	"log"
+	"monelog/model"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) UploadCSV(c echo.Context) error {
+	userId, err := getUserIdFromToken(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証に失敗しました")
+	}
+	
+	// ファイルの取得
+	file, err := c.FormFile("file")
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ファイルが見つかりません"})
+	}
+	
+	// カード種類の取得
+	cardType := c.FormValue("card_type")
+	if cardType == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "card_type is required"})
+	}
+	
+	// 年月の取得（CSVHistoryにも保存するため）
+	yearStr := c.FormValue("year")
+	monthStr := c.FormValue("month")
+	
+	year, err := strconv.Atoi(yearStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid year format"})
+	}
+	
+	month, err := strconv.Atoi(monthStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid month format"})
+	}
+	
+	request := model.CardStatementRequest{
+		CardType: cardType,
+		UserId:   userId,
+		Year:     year,
+		Month:    month,
+	}
+	
+	// CSVの処理
+	cardStatementsRes, err := h.csu.ProcessCSV(file, request)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	
+	// CSV履歴も保存する
+	csvHistoryRequest := model.CSVHistorySaveRequest{
+		FileName: file.Filename,
+		CardType: cardType,
+		Year:     year,
+		Month:    month,
+		UserId:   userId,
+	}
+	
+	// 注入されたCSV履歴ユースケースを使用
+	_, err = h.chu.SaveCSVHistory(file, csvHistoryRequest)
+	if err != nil {
+		// CSV履歴の保存に失敗しても、カード明細の処理は続行
+		// エラーログを出力するなどの対応が望ましい
+		log.Printf("Failed to save CSV history: %v", err)
+	}
+	
+	return c.JSON(http.StatusCreated, cardStatementsRes)
+}

--- a/backend/controller/card_statement/utils.go
+++ b/backend/controller/card_statement/utils.go
@@ -1,0 +1,14 @@
+package card_statement
+
+import (
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/labstack/echo/v4"
+)
+
+// getUserIdFromToken はJWTトークンからユーザーIDを取得する関数
+func getUserIdFromToken(c echo.Context) (uint, error) {
+	user := c.Get("user").(*jwt.Token)
+	claims := user.Claims.(jwt.MapClaims)
+	userId := uint(claims["user_id"].(float64))
+	return userId, nil
+}


### PR DESCRIPTION
## 概要
### card_statement_controllerのモジュール化
カード明細コントローラーを専用のサブパッケージにリファクタリングし、各ハンドラー関数を別々のファイルに分割。

## 変更内容
- カード明細コントローラーのロジックを新しいサブパッケージ `backend/controller/card_statement/` に移動
- 各ハンドラー関数を機能ごとに別々のファイルに分割
- コントローラーインターフェースを維持し、既存のAPIエンドポイントとの互換性を確保

## 新しいファイル構造
- `backend/controller/card_statement/get_all.go` - すべてのカード明細を取得する機能
- `backend/controller/card_statement/get_by_id.go` - 特定のカード明細を取得する機能
- `backend/controller/card_statement/get_by_month.go` - 月ごとの明細を取得する機能
- `backend/controller/card_statement/upload_csv.go` - CSVアップロード機能
- `backend/controller/card_statement/preview_csv.go` - CSVプレビュー機能
- `backend/controller/card_statement/save_statements.go` - カード明細を保存する機能
- `backend/controller/card_statement/handler.go` - ハンドラー構造体の定義と初期化
- `backend/controller/card_statement/utils.go` - ユーティリティ関数

## 変更されたファイル
- `backend/controller/card_statement_controller.go` - 新しいパッケージを使用するように更新

## テスト
- 既存のテストをすべて実行し、機能に回帰がないことを確認
- 各APIエンドポイントが以前と同様に機能することを手動でテスト

## 関連Issue
Closes #39