### PR TITLE
refactor/backend/card_statement_usecaseのモジュール化リファクタリング

### DIFF
--- a/backend/usecase/card_statement/get.go
+++ b/backend/usecase/card_statement/get.go
@@ -1,0 +1,47 @@
+package card_statement
+
+import (
+	"monelog/model"
+)
+
+func (csu *cardStatementUsecase) GetAllCardStatements(userId uint) ([]model.CardStatementResponse, error) {
+	cardStatements, err := csu.csr.GetAllCardStatements(userId)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]model.CardStatementResponse, len(cardStatements))
+	for i, cardStatement := range cardStatements {
+		responses[i] = cardStatement.ToResponse()
+	}
+	return responses, nil
+}
+
+func (csu *cardStatementUsecase) GetCardStatementById(userId uint, cardStatementId uint) (model.CardStatementResponse, error) {
+	cardStatement, err := csu.csr.GetCardStatementById(userId, cardStatementId)
+	if err != nil {
+		return model.CardStatementResponse{}, err
+	}
+	return cardStatement.ToResponse(), nil
+}
+
+func (csu *cardStatementUsecase) GetCardStatementsByMonth(request model.CardStatementByMonthRequest) ([]model.CardStatementResponse, error) {
+	// Validate the request
+	if err := csu.csv.ValidateCardStatementByMonthRequest(request); err != nil {
+		return nil, err
+	}
+	
+	// Get card statements for the specified month
+	cardStatements, err := csu.csr.GetCardStatementsByMonth(request.UserId, request.Year, request.Month)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Convert to response format
+	responses := make([]model.CardStatementResponse, len(cardStatements))
+	for i, cardStatement := range cardStatements {
+		responses[i] = cardStatement.ToResponse()
+	}
+	
+	return responses, nil
+}

--- a/backend/usecase/card_statement/preview_csv.go
+++ b/backend/usecase/card_statement/preview_csv.go
@@ -1,0 +1,58 @@
+package card_statement
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"monelog/model"
+	"monelog/parser"
+)
+
+func (csu *cardStatementUsecase) PreviewCSV(file *multipart.FileHeader, request model.CardStatementPreviewRequest) ([]model.CardStatementResponse, error) {
+	if err := csu.csv.ValidateCardStatementPreviewRequest(request); err != nil {
+		return nil, err
+	}
+
+	// ファイルを開く
+	src, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer src.Close()
+
+	// ファイルの内容を読み込む
+	buf := new(bytes.Buffer)
+	if _, err = io.Copy(buf, src); err != nil {
+		return nil, err
+	}
+
+	// カード種類に応じたパーサーを取得
+	cardParser, err := parser.GetParser(request.CardType)
+	if err != nil {
+		return nil, err
+	}
+
+	// CSVを解析
+	summaries, err := cardParser.Parse(buf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	// レスポンスを作成（DBには保存しない）
+	responses := make([]model.CardStatementResponse, len(summaries))
+	for i, summary := range summaries {
+		cardStatement := summary.ToModel(request.UserId, request.Year, request.Month)
+		
+		// リクエストから年月を取得して設定
+		if request.Year > 0 {
+			cardStatement.Year = request.Year
+		}
+		if request.Month > 0 {
+			cardStatement.Month = request.Month
+		}
+		
+		responses[i] = cardStatement.ToResponse()
+	}
+
+	return responses, nil
+}

--- a/backend/usecase/card_statement/process_csv.go
+++ b/backend/usecase/card_statement/process_csv.go
@@ -1,0 +1,63 @@
+package card_statement
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"monelog/model"
+	"monelog/parser"
+)
+
+func (csu *cardStatementUsecase) ProcessCSV(file *multipart.FileHeader, request model.CardStatementRequest) ([]model.CardStatementResponse, error) {
+	if err := csu.csv.ValidateCardStatementRequest(request); err != nil {
+		return nil, err
+	}
+
+	// ファイルを開く
+	src, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer src.Close()
+
+	// ファイルの内容を読み込む
+	buf := new(bytes.Buffer)
+	if _, err = io.Copy(buf, src); err != nil {
+		return nil, err
+	}
+
+	// カード種類に応じたパーサーを取得
+	cardParser, err := parser.GetParser(request.CardType)
+	if err != nil {
+		return nil, err
+	}
+
+	// CSVを解析
+	summaries, err := cardParser.Parse(buf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	// 既存のデータを削除
+	if err := csu.csr.DeleteCardStatements(request.UserId); err != nil {
+		return nil, err
+	}
+
+	// 解析結果をデータベースに保存
+	cardStatements := make([]model.CardStatement, len(summaries))
+	for i, summary := range summaries {
+		cardStatements[i] = summary.ToModel(request.UserId, request.Year, request.Month)
+	}
+
+	if err := csu.csr.CreateCardStatements(cardStatements); err != nil {
+		return nil, err
+	}
+
+	// レスポンスを作成
+	responses := make([]model.CardStatementResponse, len(cardStatements))
+	for i, cardStatement := range cardStatements {
+		responses[i] = cardStatement.ToResponse()
+	}
+
+	return responses, nil
+}

--- a/backend/usecase/card_statement/save.go
+++ b/backend/usecase/card_statement/save.go
@@ -1,0 +1,35 @@
+package card_statement
+
+import (
+	"monelog/model"
+)
+
+func (csu *cardStatementUsecase) SaveCardStatements(request model.CardStatementSaveRequest) ([]model.CardStatementResponse, error) {
+	if err := csu.csv.ValidateCardStatementSaveRequest(request); err != nil {
+		return nil, err
+	}
+
+	// 既存のデータを削除
+	if err := csu.csr.DeleteCardStatements(request.UserId); err != nil {
+		return nil, err
+	}
+
+	// 新しいデータを保存
+	cardStatements := make([]model.CardStatement, len(request.CardStatements))
+	for i, summary := range request.CardStatements {
+		// 年月を引数として渡す
+		cardStatements[i] = summary.ToModel(request.UserId, request.Year, request.Month)
+	}
+
+	if err := csu.csr.CreateCardStatements(cardStatements); err != nil {
+		return nil, err
+	}
+
+	// レスポンスを作成
+	responses := make([]model.CardStatementResponse, len(cardStatements))
+	for i, cardStatement := range cardStatements {
+		responses[i] = cardStatement.ToResponse()
+	}
+
+	return responses, nil
+}

--- a/backend/usecase/card_statement/usecase.go
+++ b/backend/usecase/card_statement/usecase.go
@@ -1,0 +1,17 @@
+package card_statement
+
+import (
+	"monelog/repository"
+	"monelog/validator"
+)
+
+// cardStatementUsecase はカード明細に関するユースケースの実装です
+type cardStatementUsecase struct {
+	csr repository.ICardStatementRepository
+	csv validator.ICardStatementValidator
+}
+
+// NewCardStatementUsecase はカード明細ユースケースの新しいインスタンスを作成します
+func NewCardStatementUsecase(csr repository.ICardStatementRepository, csv validator.ICardStatementValidator) *cardStatementUsecase {
+	return &cardStatementUsecase{csr, csv}
+}

--- a/backend/usecase/card_statement_usecase.go
+++ b/backend/usecase/card_statement_usecase.go
@@ -1,15 +1,14 @@
 package usecase
 
 import (
-	"bytes"
-	"io"
 	"mime/multipart"
 	"monelog/model"
-	"monelog/parser"
 	"monelog/repository"
+	"monelog/usecase/card_statement"
 	"monelog/validator"
 )
 
+// ICardStatementUsecase はカード明細に関するユースケースのインターフェースを定義します
 type ICardStatementUsecase interface {
 	GetAllCardStatements(userId uint) ([]model.CardStatementResponse, error)
 	GetCardStatementById(userId uint, cardStatementId uint) (model.CardStatementResponse, error)
@@ -19,186 +18,7 @@ type ICardStatementUsecase interface {
 	GetCardStatementsByMonth(request model.CardStatementByMonthRequest) ([]model.CardStatementResponse, error)
 }
 
-type cardStatementUsecase struct {
-	csr repository.ICardStatementRepository
-	csv validator.ICardStatementValidator
-}
-
+// NewCardStatementUsecase は新しいカード明細ユースケースのインスタンスを作成します
 func NewCardStatementUsecase(csr repository.ICardStatementRepository, csv validator.ICardStatementValidator) ICardStatementUsecase {
-	return &cardStatementUsecase{csr, csv}
-}
-
-func (csu *cardStatementUsecase) GetAllCardStatements(userId uint) ([]model.CardStatementResponse, error) {
-	cardStatements, err := csu.csr.GetAllCardStatements(userId)
-	if err != nil {
-		return nil, err
-	}
-
-	responses := make([]model.CardStatementResponse, len(cardStatements))
-	for i, cardStatement := range cardStatements {
-		responses[i] = cardStatement.ToResponse()
-	}
-	return responses, nil
-}
-
-func (csu *cardStatementUsecase) GetCardStatementById(userId uint, cardStatementId uint) (model.CardStatementResponse, error) {
-	cardStatement, err := csu.csr.GetCardStatementById(userId, cardStatementId)
-	if err != nil {
-		return model.CardStatementResponse{}, err
-	}
-	return cardStatement.ToResponse(), nil
-}
-
-func (csu *cardStatementUsecase) ProcessCSV(file *multipart.FileHeader, request model.CardStatementRequest) ([]model.CardStatementResponse, error) {
-	if err := csu.csv.ValidateCardStatementRequest(request); err != nil {
-		return nil, err
-	}
-
-	// ファイルを開く
-	src, err := file.Open()
-	if err != nil {
-		return nil, err
-	}
-	defer src.Close()
-
-	// ファイルの内容を読み込む
-	buf := new(bytes.Buffer)
-	if _, err = io.Copy(buf, src); err != nil {
-		return nil, err
-	}
-
-	// カード種類に応じたパーサーを取得
-	cardParser, err := parser.GetParser(request.CardType)
-	if err != nil {
-		return nil, err
-	}
-
-	// CSVを解析
-	summaries, err := cardParser.Parse(buf.Bytes())
-	if err != nil {
-		return nil, err
-	}
-
-	// 既存のデータを削除
-	if err := csu.csr.DeleteCardStatements(request.UserId); err != nil {
-		return nil, err
-	}
-
-	// 解析結果をデータベースに保存
-	cardStatements := make([]model.CardStatement, len(summaries))
-	for i, summary := range summaries {
-		cardStatements[i] = summary.ToModel(request.UserId, request.Year, request.Month)
-	}
-
-	if err := csu.csr.CreateCardStatements(cardStatements); err != nil {
-		return nil, err
-	}
-
-	// レスポンスを作成
-	responses := make([]model.CardStatementResponse, len(cardStatements))
-	for i, cardStatement := range cardStatements {
-		responses[i] = cardStatement.ToResponse()
-	}
-
-	return responses, nil
-}
-
-func (csu *cardStatementUsecase) PreviewCSV(file *multipart.FileHeader, request model.CardStatementPreviewRequest) ([]model.CardStatementResponse, error) {
-	if err := csu.csv.ValidateCardStatementPreviewRequest(request); err != nil {
-		return nil, err
-	}
-
-	// ファイルを開く
-	src, err := file.Open()
-	if err != nil {
-		return nil, err
-	}
-	defer src.Close()
-
-	// ファイルの内容を読み込む
-	buf := new(bytes.Buffer)
-	if _, err = io.Copy(buf, src); err != nil {
-		return nil, err
-	}
-
-	// カード種類に応じたパーサーを取得
-	cardParser, err := parser.GetParser(request.CardType)
-	if err != nil {
-		return nil, err
-	}
-
-	// CSVを解析
-	summaries, err := cardParser.Parse(buf.Bytes())
-	if err != nil {
-		return nil, err
-	}
-
-	// レスポンスを作成（DBには保存しない）
-	responses := make([]model.CardStatementResponse, len(summaries))
-	for i, summary := range summaries {
-		cardStatement := summary.ToModel(request.UserId, request.Year, request.Month)
-		
-		// リクエストから年月を取得して設定（PreviewRequestに年月を追加する必要あり）
-		if request.Year > 0 {
-			cardStatement.Year = request.Year
-		}
-		if request.Month > 0 {
-			cardStatement.Month = request.Month
-		}
-		
-		responses[i] = cardStatement.ToResponse()
-	}
-
-	return responses, nil
-}
-
-func (csu *cardStatementUsecase) SaveCardStatements(request model.CardStatementSaveRequest) ([]model.CardStatementResponse, error) {
-	if err := csu.csv.ValidateCardStatementSaveRequest(request); err != nil {
-		return nil, err
-	}
-
-	// 既存のデータを削除
-	if err := csu.csr.DeleteCardStatements(request.UserId); err != nil {
-		return nil, err
-	}
-
-	// 新しいデータを保存
-	cardStatements := make([]model.CardStatement, len(request.CardStatements))
-	for i, summary := range request.CardStatements {
-		// 年月を引数として渡す
-		cardStatements[i] = summary.ToModel(request.UserId, request.Year, request.Month)
-	}
-
-	if err := csu.csr.CreateCardStatements(cardStatements); err != nil {
-		return nil, err
-	}
-
-	// レスポンスを作成
-	responses := make([]model.CardStatementResponse, len(cardStatements))
-	for i, cardStatement := range cardStatements {
-		responses[i] = cardStatement.ToResponse()
-	}
-
-	return responses, nil
-}
-
-func (csu *cardStatementUsecase) GetCardStatementsByMonth(request model.CardStatementByMonthRequest) ([]model.CardStatementResponse, error) {
-	// Validate the request
-	if err := csu.csv.ValidateCardStatementByMonthRequest(request); err != nil {
-		return nil, err
-	}
-	
-	// Get card statements for the specified month
-	cardStatements, err := csu.csr.GetCardStatementsByMonth(request.UserId, request.Year, request.Month)
-	if err != nil {
-		return nil, err
-	}
-	
-	// Convert to response format
-	responses := make([]model.CardStatementResponse, len(cardStatements))
-	for i, cardStatement := range cardStatements {
-		responses[i] = cardStatement.ToResponse()
-	}
-	
-	return responses, nil
+	return card_statement.NewCardStatementUsecase(csr, csv)
 }


### PR DESCRIPTION
## 概要
### カード明細ユースケースのモジュール化リファクタリング
カード明細に関するユースケースの実装をモジュール化し、コードの整理と保守性の向上。

## 変更内容
- カード明細ユースケースのインターフェースと実装を分離
- 各機能ごとにファイルを分割し、関心事の分離を実現
- コードの可読性と保守性の向上

## 変更詳細
- `backend/usecase/card_statement_usecase.go`: インターフェース定義と初期化関数
- `backend/usecase/card_statement/usecase.go`: ユースケース構造体の定義
- `backend/usecase/card_statement/get.go`: 取得機能の実装
- `backend/usecase/card_statement/preview_csv.go`: CSVプレビュー機能の実装
- `backend/usecase/card_statement/process_csv.go`: CSV処理機能の実装
- `backend/usecase/card_statement/save.go`: 保存機能の実装

## テスト
- 既存の機能が正常に動作することを確認
- 各ユースケースが適切に分離され、独立して動作することを確認

## レビューポイント
- コードの分割方法は適切か
- インターフェースと実装の分離は明確か
- 各機能の責務が適切に分離されているか

## 関連Issue
Closes #45

